### PR TITLE
fix: rule_tracker 피드백 루프 완성 (도메인별 인과 측정)

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -147,17 +147,29 @@ jobs:
           python3 - <<'PYEOF'
           import json, sys
           sys.path.insert(0, 'src')
-          from rule_tracker import record_snapshot
+          from rule_tracker import record_snapshot, record_new_rules
           import os
 
           d = json.load(open('/tmp/report.json'))
           date = os.environ.get('REPORT_DATE', '')
-          domain_rates = {
-              dc['domain']: dc['fix_count']
-              for dc in d.get('domain_counts', [])
-          }
-          record_snapshot(domain_rates, d['summary']['fix_rate'], date)
+          total_fix = d['summary']['fix_rate']
+          total_prs = d['summary']['total_prs']
+
+          # domain_counts는 raw count → 비율(%)로 변환
+          domain_rates = {}
+          for dc in d.get('domain_counts', []):
+              if total_prs > 0:
+                  domain_rates[dc['domain']] = round(dc['fix_count'] / total_prs * 100, 1)
+
+          # 1) 스냅샷 기록
+          record_snapshot(domain_rates, total_fix, date)
           print(f"스냅샷 기록 완료: {date}")
+
+          # 2) 오늘 제안된 규칙을 히스토리에 등록 (추가 시점 fix-rate 기준점 저장)
+          rules = d.get('claude_md_suggestions', [])
+          if rules:
+              added = record_new_rules(rules, domain_rates, total_fix, date)
+              print(f"신규 규칙 등록: {len(added)}개")
           PYEOF
         env:
           REPORT_DATE: ${{ steps.analyze.outputs.date }}

--- a/src/rule_tracker.py
+++ b/src/rule_tracker.py
@@ -9,14 +9,36 @@
 
 import json
 import hashlib
-from datetime import datetime
+import re
 from pathlib import Path
 
 HISTORY_FILE = Path(__file__).parent.parent / "data" / "rules-history.json"
 
+# 규칙 텍스트에서 도메인 힌트를 추출하는 패턴
+_DOMAIN_HINTS = [
+    ("ci/cd",        r"CI/CD|Docker|deploy|dockerfile|healthcheck|compose|buildx"),
+    ("auth",         r"인증|auth|login|session|signin|credential"),
+    ("payment",      r"결제|payment|portone|checkout|order"),
+    ("database",     r"Prisma|schema|migration|DB"),
+    ("security",     r"CSP|XSS|rate.limit|sanitize|allowlist"),
+    ("external-api", r"Kakao|PortOne|GCS|외부.API"),
+    ("test/e2e",     r"E2E|테스트|playwright|vitest|coverage|standalone"),
+    ("config",       r"next\.config|env\.ts|tsconfig|biome"),
+    ("api",          r"API Route|route\.ts"),
+    ("ui",           r"컴포넌트|component|page\.tsx"),
+]
+
 
 def _rule_id(rule: str) -> str:
     return hashlib.md5(rule.strip().encode()).hexdigest()[:8]
+
+
+def _infer_domain(rule: str) -> str:
+    """규칙 텍스트에서 도메인을 추론. 매칭 없으면 'general'."""
+    for domain, pattern in _DOMAIN_HINTS:
+        if re.search(pattern, rule, re.I):
+            return domain
+    return "general"
 
 
 def load_history() -> dict:
@@ -49,9 +71,11 @@ def record_new_rules(
         rid = _rule_id(rule)
         if rid in existing_ids:
             continue
+        domain = _infer_domain(rule)
         history["rules"].append({
             "id": rid,
             "rule": rule,
+            "domain": domain,
             "date_added": date,
             "fix_rate_at_add": {
                 "total": total_fix_rate,
@@ -73,7 +97,6 @@ def record_snapshot(
     """매일 현재 fix-rate를 모든 활성 규칙의 스냅샷으로 기록"""
     history = load_history()
 
-    # 전체 스냅샷 로그
     history.setdefault("snapshots", []).append({
         "date": date,
         "total_fix_rate": total_fix_rate,
@@ -85,14 +108,12 @@ def record_snapshot(
         seen[s["date"]] = s
     history["snapshots"] = list(seen.values())
 
-    # 각 규칙별 스냅샷 추가
     for rule in history["rules"]:
         rule.setdefault("snapshots", []).append({
             "date": date,
             "total": total_fix_rate,
             **domain_fix_rates,
         })
-        # 180일 이상 된 스냅샷 정리
         rule["snapshots"] = rule["snapshots"][-180:]
 
     save_history(history)
@@ -101,6 +122,8 @@ def record_snapshot(
 def compute_effectiveness(min_days: int = 7) -> list[dict]:
     """
     규칙 추가 전후 fix-rate 비교.
+    규칙에 도메인이 있으면 해당 도메인 fix-rate 변화를 사용.
+    도메인 데이터가 없으면 전체 fix-rate로 폴백.
     min_days 이상 경과된 규칙만 평가.
     """
     history = load_history()
@@ -112,17 +135,29 @@ def compute_effectiveness(min_days: int = 7) -> list[dict]:
             continue
 
         at_add = rule["fix_rate_at_add"]
-        recent = snapshots[-7:]  # 최근 7일 평균
-        recent_total = sum(s.get("total", 0) for s in recent) / len(recent)
-        delta = round(recent_total - at_add.get("total", 0), 1)
+        domain = rule.get("domain", "general")
+        recent = snapshots[-7:]
 
+        # 도메인별 fix-rate가 스냅샷에 있으면 우선 사용
+        if domain != "general" and domain in at_add and all(domain in s for s in recent):
+            before = at_add[domain]
+            after = round(sum(s[domain] for s in recent) / len(recent), 1)
+            scope = f"도메인({domain})"
+        else:
+            before = at_add.get("total", 0)
+            after = round(sum(s.get("total", 0) for s in recent) / len(recent), 1)
+            scope = "전체"
+
+        delta = round(after - before, 1)
         results.append({
             "rule": rule["rule"][:80],
+            "domain": domain,
+            "scope": scope,
             "date_added": rule["date_added"],
-            "fix_rate_at_add": at_add.get("total"),
-            "fix_rate_recent": round(recent_total, 1),
+            "fix_rate_at_add": before,
+            "fix_rate_recent": after,
             "delta": delta,
-            "effective": delta < 0,  # fix-rate 감소 = 효과 있음
+            "effective": delta < 0,
         })
 
     return sorted(results, key=lambda x: x["delta"])
@@ -136,8 +171,8 @@ def effectiveness_summary() -> str:
     lines = ["### 📈 규칙 효과 측정"]
     for r in results:
         sign = "▼" if r["effective"] else "▲"
-        color = "개선" if r["effective"] else "미변화"
-        delta_str = f"{sign} {abs(r['delta'])}%p ({color})"
+        label = "개선" if r["effective"] else "미변화"
+        delta_str = f"{sign} {abs(r['delta'])}%p ({label}, {r['scope']} 기준)"
         lines.append(
             f"- **{r['date_added']}** 추가 | "
             f"fix율 {r['fix_rate_at_add']}% → {r['fix_rate_recent']}% {delta_str}\n"


### PR DESCRIPTION
## 수정된 버그 3개

### Bug 1 — `record_new_rules`가 워크플로우에서 호출되지 않음
규칙이 추가된 시점의 fix-rate 기준점이 저장되지 않아 before/after 비교 자체가 불가능했음.
`record_snapshot` 스텝에서 `record_new_rules`를 함께 호출하도록 수정.

### Bug 2 — domain_rates에 비율 대신 raw count 저장
`compute_effectiveness`는 `float` 퍼센트를 기대하는데 정수 횟수가 들어가 계산이 깨짐.
`fix_count / total_prs * 100`으로 변환 후 전달.

### Bug 3 — 도메인 규칙을 전체 fix-rate로 평가
ci/cd 규칙을 추가했을 때 ci/cd 도메인 fix-rate가 아닌 전체 fix-rate 변화를 봤음.
`compute_effectiveness`에서 규칙의 `domain` 필드와 일치하는 도메인 fix-rate를 우선 사용,
없으면 전체 fix-rate로 폴백.

### 추가: `_infer_domain()`
규칙 텍스트에서 도메인을 자동 추론. 호출자가 별도로 도메인을 지정할 필요 없음.

## 단위 테스트 결과
```
테스트 통과 ✓
  도메인: ci/cd, scope: 도메인(ci/cd)
  추가 시점 30.0% → 최근 15.0% (delta -15.0%p)
```

## 머지 순서
`#2` → `#3` → `#4` (이 PR) 순서 권장. 이 PR은 독립 파일(rule_tracker.py + evolve-rules.yml)만 수정하므로 #2·#3과 충돌 없음.