### PR TITLE
feat: RAG를 통계 요약 → 실제 diff 패턴 임베딩으로 전환

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -175,11 +175,59 @@ jobs:
         env:
           REPORT_DATE: ${{ steps.analyze.outputs.date }}
 
-      - name: Commit history file
+      # ── 3.5단계: diff 패턴 누적 저장 (RAG 임베딩용) ────────────────────────
+      - name: diff 패턴 저장
+        continue-on-error: true
+        run: |
+          python3 - <<'PYEOF'
+          import json, os
+          from pathlib import Path
+          from datetime import datetime
+
+          d = json.load(open('/tmp/report.json'))
+          date = os.environ.get('REPORT_DATE', datetime.now().strftime('%Y-%m-%d'))
+          repo = "rladmsgh34/gwangcheon-shop"
+
+          patterns_path = Path("data/diff-patterns.json")
+          existing = json.loads(patterns_path.read_text()) if patterns_path.exists() else {"patterns": []}
+
+          # 이미 저장된 PR 번호 목록
+          saved_prs = {(e["repo"], e["pr_number"]) for e in existing["patterns"]}
+
+          new_count = 0
+          for pr in d.get("fix_prs_with_diff", []):
+              key = (repo, pr["number"])
+              if key in saved_prs:
+                  continue
+              diff = pr.get("diff_snippet", "").strip()
+              if not diff:
+                  continue
+              existing["patterns"].append({
+                  "repo": repo,
+                  "pr_number": pr["number"],
+                  "title": pr.get("title", ""),
+                  "domain": pr.get("domain", "general"),
+                  "files": pr.get("files", []),
+                  "diff_snippet": diff[:800],  # 800자 제한
+                  "date": date,
+              })
+              new_count += 1
+
+          # 최대 500개 유지 (오래된 것부터 제거)
+          existing["patterns"] = existing["patterns"][-500:]
+          existing["updated_at"] = date
+
+          patterns_path.write_text(json.dumps(existing, ensure_ascii=False, indent=2))
+          print(f"diff 패턴 {new_count}개 추가 (누적 {len(existing['patterns'])}개)")
+          PYEOF
+        env:
+          REPORT_DATE: ${{ steps.analyze.outputs.date }}
+
+      - name: 히스토리 파일 커밋
         run: |
           git config user.name "ai-dev-loop-analyzer[bot]"
           git config user.email "ai-dev-loop-analyzer@users.noreply.github.com"
-          git add data/rules-history.json
+          git add data/rules-history.json data/diff-patterns.json
           git diff --staged --quiet || git commit -m "data: daily snapshot ${{ steps.analyze.outputs.date }}"
           git push
 

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -490,6 +490,17 @@ def print_report(
     ai_stats = analyze_ai_vs_human(prs)
 
     if output_format == "json":
+        fix_prs_with_diff = [
+            {
+                "number": p.number,
+                "title": p.title,
+                "domain": p.domain,
+                "files": p.files,
+                "diff_snippet": p.diff_snippet,
+            }
+            for p in prs
+            if p.is_fix and p.diff_snippet
+        ]
         print(json.dumps({
             "summary": {"total_prs": total, "fix_prs": fix_count, "fix_rate": round(fix_rate, 1)},
             "clusters": [{"start": c.start, "end": c.end, "size": c.size, "domain": c.domain} for c in clusters],
@@ -497,6 +508,7 @@ def print_report(
             "domain_counts": [{"domain": d, "fix_count": n} for d, n in domain_counts],
             "claude_md_suggestions": rules,
             "ai_vs_human": ai_stats,
+            "fix_prs_with_diff": fix_prs_with_diff,
         }, ensure_ascii=False, indent=2))
         return
 

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -202,6 +202,52 @@ def load_analysis_cache() -> list[dict]:
     return chunks
 
 
+def load_diff_patterns() -> list[dict]:
+    """diff-patterns.json → 청크 리스트.
+    각 항목은 실제 fix PR의 diff snippet + 도메인 + 레포 정보를 담는다.
+    통계 요약이 아닌 실제 코드 패턴을 임베딩해 RAG 검색 품질을 높인다.
+    """
+    path = DATA_DIR / "diff-patterns.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return []
+
+    chunks = []
+    for entry in data.get("patterns", []):
+        pr_num = entry.get("pr_number", 0)
+        title = entry.get("title", "")
+        domain = entry.get("domain", "general")
+        repo = entry.get("repo", "unknown")
+        date = entry.get("date", "")
+        diff = entry.get("diff_snippet", "").strip()
+        files = ", ".join(entry.get("files", [])[:5])
+
+        if not diff:
+            continue
+
+        chunk_id = f"diff_{repo.replace('/', '_')}_{pr_num}"
+        chunks.append({
+            "id": chunk_id,
+            "text": (
+                f"[{repo}] fix PR #{pr_num} ({domain}): {title}\n"
+                f"변경 파일: {files}\n"
+                f"diff:\n{diff[:600]}"  # 600자로 청크 크기 제한
+            ),
+            "metadata": {
+                "type": "diff_pattern",
+                "domain": domain,
+                "repo": repo,
+                "pr_number": pr_num,
+                "date": date,
+            },
+        })
+
+    return chunks
+
+
 def ingest(append: bool = False):
     collection = get_collection()
 
@@ -223,6 +269,7 @@ def ingest(append: bool = False):
     all_chunks.extend(load_language_patterns())
     all_chunks.extend(load_rules_history())
     all_chunks.extend(load_analysis_cache())
+    all_chunks.extend(load_diff_patterns())
 
     new_chunks = [c for c in all_chunks if c["id"] not in existing_ids]
 

--- a/src/rag/query.py
+++ b/src/rag/query.py
@@ -58,40 +58,62 @@ class RagEngine:
     ) -> list[str]:
         """RAG 컨텍스트를 활용해 Claude Code CLI로 규칙을 생성합니다."""
 
-        # 1. 관련 패턴 검색
-        query = f"{domain} 회귀 패턴 fix {language}".strip()
-        docs = self.retrieve(query, n_retrieve)
+        # 1. diff 패턴 우선 검색 — 실제 코드 변경이 가장 구체적인 컨텍스트
+        diff_query = f"{domain} fix 코드 변경 패턴 {language}".strip()
+        where_diff = {"type": "diff_pattern"} if self._has_diff_patterns() else None
+        diff_docs = self.retrieve(diff_query, n_retrieve, where=where_diff)
 
-        # 언어 특화 패턴도 추가 검색
-        if language:
-            lang_docs = self.retrieve(f"{language} {domain} 취약 도메인", n_retrieve // 2)
-            docs = list(dict.fromkeys(docs + lang_docs))  # 중복 제거
+        # 2. 통계/요약 검색 — diff가 없거나 부족할 때 보완
+        stat_docs = self.retrieve(f"{domain} 회귀 취약 도메인 {language}".strip(), n_retrieve // 2)
 
-        context_text = "\n".join(f"  - {d}" for d in docs[:n_retrieve])
+        # diff 패턴을 앞에 배치 (더 구체적이므로 우선)
+        all_docs = list(dict.fromkeys(diff_docs + stat_docs))[:n_retrieve]
+
+        diff_section = ""
+        stat_section = ""
+        for doc in all_docs:
+            if "diff:" in doc:
+                diff_section += f"\n---\n{doc}"
+            else:
+                stat_section += f"\n  - {doc}"
+
+        context_block = ""
+        if diff_section:
+            context_block += f"\n## 유사 레포의 실제 fix diff\n{diff_section}"
+        if stat_section:
+            context_block += f"\n## 통계 기반 패턴\n{stat_section}"
+        if not context_block:
+            context_block = "\n## 참고 데이터\n  (아직 수집된 데이터 없음)"
 
         prompt = f"""당신은 AI 코딩 어시스턴트 규칙 전문가입니다.
-아래 데이터 기반 인사이트를 참고해서 CLAUDE.md에 추가할 실용적인 규칙을 생성하세요.
+아래 데이터를 참고해서 CLAUDE.md에 추가할 실용적인 규칙을 생성하세요.
 
 ## 현재 상황
 - 분석 대상 도메인: {domain}
 - 현재 fix율: {fix_rate}%
 - 언어: {language or "미지정"}
 {f"- 추가 컨텍스트: {extra_context}" if extra_context else ""}
-
-## 유사 레포에서 수집된 패턴
-{context_text if context_text else "  (아직 수집된 데이터 없음)"}
+{context_block}
 
 ## 요청
 위 데이터를 바탕으로 {domain} 도메인의 회귀를 줄이기 위한 CLAUDE.md 규칙을 3개 생성하세요.
 
 요구사항:
 - 각 규칙은 한 문장으로 명확하게 (구체적인 행동 지침 포함)
-- 데이터에서 관찰된 패턴을 근거로 할 것
+- diff가 있으면 그 안의 구체적인 함수명·파일명·설정값을 규칙에 반영
 - 번호 없이 한 줄씩 출력
 
 규칙만 출력하고 설명은 생략하세요."""
 
         return self._call_claude(prompt, model)
+
+    def _has_diff_patterns(self) -> bool:
+        """ChromaDB에 diff_pattern 타입 청크가 있는지 확인."""
+        try:
+            results = self.collection.get(where={"type": "diff_pattern"}, limit=1)
+            return len(results["ids"]) > 0
+        except Exception:
+            return False
 
     def explain_cluster(
         self,


### PR DESCRIPTION
## 문제

기존 ChromaDB 임베딩 대상:
```
"TypeScript 레포 5개 분석, 평균 fix율 42%, top 도메인: ci/cd"
```
→ 통계 요약이라 규칙 생성 시 구체적인 코드 패턴을 못 씀

## 변경 후 임베딩 대상 (추가)
```
[gwangcheon-shop] fix PR #58 (ci/cd): Dockerfile deps 스테이지 수정
변경 파일: Dockerfile
diff:
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml .npmrc ./
 RUN pnpm install --frozen-lockfile
```
→ "`.npmrc`를 deps 스테이지에 COPY 안 하면 사설 패키지 설치 실패"라는 규칙이 나옴

## 변경 파일

### `analyze.py`
- `PR` 데이터클래스에 `diff_snippet` 필드 추가
- JSON 출력에 `fix_prs_with_diff` 배열 포함

### `rag/ingest.py`
- `load_diff_patterns()` 추가 — `data/diff-patterns.json` → diff 청크

### `rag/query.py`
- `generate_rules()`: diff_pattern 타입 청크 우선 검색 → 통계 청크로 보완
- 프롬프트: "diff에서 함수명·파일명·설정값을 규칙에 반영" 명시

### `evolve-rules.yml`
- 스텝 3.5 추가: 분석 결과에서 diff snippet 추출 → `data/diff-patterns.json` 누적
- 일일 커밋에 `data/diff-patterns.json` 포함

## 머지 순서
`#2` → `#3` → `#4` → `#5` → `#6` (이 PR)