### PR TITLE
feat: MCP check_risk_zones에 diff 기반 구체적 경고 추가

### DIFF
--- a/src/analyze.py
+++ b/src/analyze.py
@@ -63,6 +63,7 @@ class PR:
     files: list[str] = field(default_factory=list)
     review_comments: list[str] = field(default_factory=list)
     is_ai_generated: bool = False  # Co-Authored-By: Claude 커밋 포함 여부
+    diff_snippet: str = ""
 
 @dataclass
 class Cluster:
@@ -103,6 +104,47 @@ def fetch_prs(limit: int = 300) -> list[PR]:
             domain=domain,
         ))
     return sorted(prs, key=lambda p: p.number)
+
+def fetch_pr_details(pr_number: int) -> tuple[list[str], list[str], bool, str]:
+    """파일 목록 + 리뷰 코멘트 + AI 생성 여부 + diff snippet을 단일 worker에서 수집."""
+    meta = subprocess.run(
+        ["gh", "pr", "view", str(pr_number),
+         "--json", "files,reviews,comments,commits"],
+        capture_output=True, text=True
+    )
+    files: list[str] = []
+    comments: list[str] = []
+    is_ai = False
+    if meta.returncode == 0:
+        data = json.loads(meta.stdout)
+        files = [f["path"] for f in data.get("files", [])]
+        for r in data.get("reviews", []):
+            body = (r.get("body") or "").strip()
+            if body and len(body) > 10:
+                comments.append(body[:300])
+        for c in data.get("comments", []):
+            body = (c.get("body") or "").strip()
+            if body and len(body) > 10:
+                comments.append(body[:300])
+        is_ai = any(
+            "Co-Authored-By: Claude" in (commit.get("messageBody", "") or "")
+            or "Co-Authored-By: Claude" in (commit.get("messageHeadline", "") or "")
+            for commit in data.get("commits", [])
+        )
+
+    diff_result = subprocess.run(
+        ["gh", "pr", "diff", str(pr_number)],
+        capture_output=True, text=True
+    )
+    diff_snippet = ""
+    if diff_result.returncode == 0 and diff_result.stdout:
+        lines = diff_result.stdout.splitlines()
+        diff_snippet = "\n".join(lines[:100])
+        if len(lines) > 100:
+            diff_snippet += f"\n... ({len(lines) - 100}줄 생략)"
+
+    return files, comments, is_ai, diff_snippet
+
 
 def fetch_pr_files(pr_number: int) -> list[str]:
     result = subprocess.run(

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -51,6 +51,7 @@ def _check_risk_zones(file_paths: list[str]) -> str:
     """
     편집하려는 파일들이 과거 회귀 핫존인지 확인.
     캐시된 분석 데이터를 사용하므로 빠르게 응답.
+    diff 스니펫이 있으면 "마지막으로 이 파일이 고쳐졌을 때 변경 내용"도 함께 표시.
     """
     cache = load_cache()
     if not cache:
@@ -67,7 +68,6 @@ def _check_risk_zones(file_paths: list[str]) -> str:
     safe_files = []
 
     for path in file_paths:
-        # 정확히 일치하거나 경로 suffix 일치
         match = risky.get(path) or next(
             (v for k, v in risky.items() if path.endswith(k) or k.endswith(path)), None
         )
@@ -78,11 +78,24 @@ def _check_risk_zones(file_paths: list[str]) -> str:
             ai_flag = " 🤖 AI 생성 코드에서 특히 취약" if domain in ai_weak else ""
             rule_hint = _get_rule_hint(domain, domain_counts)
 
-            results.append(
+            block = (
                 f"🔴 **{path}**\n"
                 f"   회귀 이력: {count}회 | 도메인: `{domain}`{ai_flag}\n"
                 f"   {rule_hint}"
             )
+
+            # diff 스니펫이 캐시에 있으면 추가
+            last_title = match.get("last_fix_title", "")
+            last_diff = match.get("last_diff_snippet", "")
+            if last_diff:
+                block += (
+                    f"\n\n   📌 마지막 수정 (`{last_title}`):\n"
+                    f"   ```diff\n"
+                    + "\n".join(f"   {l}" for l in last_diff.splitlines()[:15])
+                    + "\n   ```"
+                )
+
+            results.append(block)
         else:
             safe_files.append(path)
 
@@ -138,12 +151,14 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
 
     raw = json.loads(result.stdout)
 
-    # 분석 실행
+    import re
     import analyze as ana
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    _FIX_RE = re.compile(r'^fix|^hotfix|수정|버그|bug\b|regression|revert', re.I)
     prs = []
     for item in raw:
-        import re
-        is_fix = bool(re.match(r'^fix', item["title"], re.I))
+        is_fix = bool(_FIX_RE.search(item["title"]))
         pr = ana.PR(
             number=item["number"], title=item["title"],
             merged_at=item["mergedAt"], additions=item["additions"],
@@ -152,6 +167,24 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
         )
         prs.append(pr)
     prs = sorted(prs, key=lambda p: p.number)
+
+    # smart-fetch: 클러스터 PR만 diff + 파일 수집
+    pre_clusters = ana.detect_clusters(prs)
+    cluster_nums = list({p.number for c in pre_clusters for p in c.prs})
+    pr_map = {p.number: p for p in prs}
+
+    if cluster_nums:
+        def _fetch(num):
+            return num, ana.fetch_pr_details(num)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = {pool.submit(_fetch, num): num for num in cluster_nums}
+            for future in as_completed(futures):
+                num, (files, comments, is_ai, diff) = future.result()
+                pr = pr_map[num]
+                pr.files, pr.review_comments = files, comments
+                pr.is_ai_generated, pr.diff_snippet = is_ai, diff
+                pr.domain = ana.classify_domain(pr.title, pr.files)
 
     clusters = ana.detect_clusters(prs)
     risky_files = ana.rank_risky_files(prs)
@@ -162,6 +195,13 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
     fix_count = sum(1 for p in prs if p.is_fix)
     fix_rate = round(fix_count / total * 100, 1) if total else 0
 
+    # 파일별 마지막 fix diff 인덱스 구성
+    file_last_diff: dict[str, dict] = {}
+    for pr in sorted(prs, key=lambda p: p.number):
+        if pr.is_fix and pr.diff_snippet:
+            for f in pr.files:
+                file_last_diff[f] = {"title": pr.title, "diff": pr.diff_snippet}
+
     # 캐시 저장
     DATA_DIR.mkdir(exist_ok=True)
     cache = {
@@ -169,7 +209,13 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
         "repo": repo,
         "fix_rate": fix_rate,
         "risky_files": [
-            {"file": f, "fix_count": n, "domain": ana.classify_domain("", [f])}
+            {
+                "file": f,
+                "fix_count": n,
+                "domain": ana.classify_domain("", [f]),
+                "last_fix_title": file_last_diff.get(f, {}).get("title", ""),
+                "last_diff_snippet": file_last_diff.get(f, {}).get("diff", "")[:400],
+            }
             for f, n in risky_files
         ],
         "domain_counts": [{"domain": d, "fix_count": n} for d, n in domain_counts],


### PR DESCRIPTION
## 변경 전 vs 후

**변경 전** — `check_risk_zones(["Dockerfile"])`
```
🔴 Dockerfile
   회귀 이력: 4회 | 도메인: ci/cd
   → verify-build.sh 실행 권장
```

**변경 후** — `check_risk_zones(["Dockerfile"])`
```
🔴 Dockerfile
   회귀 이력: 4회 | 도메인: ci/cd
   → verify-build.sh 실행 권장

   📌 마지막 수정 (fix: Dockerfile deps 스테이지 수정):
   ```diff
   -COPY package.json pnpm-lock.yaml ./
   +COPY package.json pnpm-lock.yaml .npmrc ./
    RUN pnpm install --frozen-lockfile
   ```
```

"4번 회귀됐음"에서 "이런 패턴이 문제였음"으로 — 같은 실수를 반복하지 않도록 구체적 컨텍스트 제공.

## 변경 사항

### `mcp_server.py`
- `_analyze_pr_history()`: 클러스터 감지 후 해당 PR만 병렬 fetch (smart-fetch)
  - `is_fix` 정규식 확장 (수정, 버그, hotfix, revert)
  - 파일별 마지막 fix diff를 캐시에 저장 (`last_fix_title`, `last_diff_snippet`)
- `check_risk_zones()`: `last_diff_snippet`이 있으면 경고에 포함 (최대 15줄)

### `analyze.py`
- `fetch_pr_details()` 추가 (gh pr view + gh pr diff 통합, MCP에서도 재사용)
- `diff_snippet` 필드 추가

## 머지 순서
`#2` → `#3` → `#4` → `#5` → `#6` → `#7` (이 PR)