### PR TITLE
feat: PR merge 즉시 분석 트리거 (repository_dispatch)

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -13,6 +13,8 @@ on:
         description: 'fix PR 파일 + 리뷰 코멘트 수집 (더 정확, 느림)'
         type: boolean
         default: true
+  repository_dispatch:
+    types: [pr-merged]
 
 jobs:
   evolve:
@@ -21,6 +23,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+    env:
+      IS_PR_TRIGGER: ${{ github.event_name == 'repository_dispatch' }}
 
     steps:
       - name: Checkout ai-dev-loop-analyzer
@@ -49,16 +53,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           AI_DEV_LOOP_PROFILE: gwangcheon-shop/.claude/ai-dev-loop-profile.json
         run: |
+          LIMIT=300
+          FETCH_FLAG="--fetch-files"
+          if [ "$IS_PR_TRIGGER" = "true" ]; then
+            LIMIT=50
+            FETCH_FLAG=""
+          elif [ "${{ inputs.fetch_files }}" = "false" ]; then
+            FETCH_FLAG=""
+          fi
+
           gh pr list \
             --repo rladmsgh34/gwangcheon-shop \
-            --state merged --limit 300 \
+            --state merged --limit $LIMIT \
             --json number,title,mergedAt,additions,deletions \
             > /tmp/prs.json
-
-          FETCH_FLAG=""
-          if [ "${{ inputs.fetch_files }}" != "false" ]; then
-            FETCH_FLAG="--fetch-files"
-          fi
 
           python3 src/analyze.py \
             --input /tmp/prs.json \
@@ -72,9 +80,11 @@ jobs:
           echo "fix_rate=$FIX_RATE" >> $GITHUB_OUTPUT
           echo "cluster_count=$CLUSTER_COUNT" >> $GITHUB_OUTPUT
           echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          echo "is_pr_trigger=$IS_PR_TRIGGER" >> $GITHUB_OUTPUT
 
       # ── Step 2: issue report ───────────────────────────────────────────────
       - name: Post daily report issue
+        if: env.IS_PR_TRIGGER != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -233,6 +243,7 @@ jobs:
 
       # ── Step 4: patch CLAUDE.md ────────────────────────────────────────────
       - name: Generate CLAUDE.md patch
+        if: env.IS_PR_TRIGGER != 'true'
         continue-on-error: true
         id: patch
         run: |


### PR DESCRIPTION
## 변경 사항

### evolve-rules.yml — `repository_dispatch: pr-merged` 트리거 추가

gwangcheon-shop에서 PR이 main에 머지될 때 즉시 가벼운 분석을 실행.

**PR-trigger 경로 vs 스케줄 경로 비교:**

| 항목 | schedule (daily) | repository_dispatch |
|------|-----------------|---------------------|
| PR 수집 limit | 300 | 50 |
| fetch 방식 | `--fetch-files` | smart-fetch |
| 이슈 포스팅 | ✅ | ❌ (생략) |
| CLAUDE.md 패치 | ✅ | ❌ (생략) |
| diff 패턴 저장 | ✅ | ✅ |
| 스냅샷 기록 | ✅ | ✅ |

**IS_PR_TRIGGER** env를 job 레벨에서 설정해 각 스텝이 조건 분기.

## 연계 PR
gwangcheon-shop `feat/notify-ai-analyzer` 브랜치 — 이 dispatch를 발송하는 workflow 포함.

## 주의사항
gwangcheon-shop에 `GH_PAT` 시크릿이 없는 경우 notify workflow가 403 반환.  
ai-dev-loop-analyzer와 동일한 PAT을 gwangcheon-shop Secrets에 추가 필요.

## 테스트
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/evolve-rules.yml'))"` 통과
- [ ] `workflow_dispatch`로 수동 실행 후 정상 동작 확인 (머지 후)