### PR TITLE
refactor: 하드코딩된 gwangcheon-shop 제거 — 멀티 프로젝트 지원

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 1 * * *'   # 매일 오전 10시 KST
   workflow_dispatch:
     inputs:
+      target_repo:
+        description: '분석할 레포 (예: owner/repo). 미입력 시 vars.TARGET_REPO 사용.'
+        required: false
+        default: ''
       dry_run:
         description: 'Dry run — 분석만 하고 PR 생성 생략'
         type: boolean
@@ -24,6 +28,7 @@ jobs:
       issues: write
       pull-requests: write
     env:
+      TARGET_REPO: ${{ inputs.target_repo || vars.TARGET_REPO || 'rladmsgh34/gwangcheon-shop' }}
       IS_PR_TRIGGER: ${{ github.event_name == 'repository_dispatch' }}
 
     steps:
@@ -39,19 +44,19 @@ jobs:
           mkdir -p data
           touch data/rules-history.json
 
-      - name: Checkout gwangcheon-shop
+      - name: Checkout target repo
         uses: actions/checkout@v4
         with:
-          repository: rladmsgh34/gwangcheon-shop
+          repository: ${{ env.TARGET_REPO }}
           token: ${{ secrets.GH_PAT }}
-          path: gwangcheon-shop
+          path: target-repo
 
       # ── Step 1: analyze ─────────────────────────────────────────────────────
       - name: Collect and analyze PR history
         id: analyze
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          AI_DEV_LOOP_PROFILE: gwangcheon-shop/.claude/ai-dev-loop-profile.json
+          AI_DEV_LOOP_PROFILE: target-repo/.claude/ai-dev-loop-profile.json
         run: |
           LIMIT=300
           FETCH_FLAG="--fetch-files"
@@ -63,7 +68,7 @@ jobs:
           fi
 
           gh pr list \
-            --repo rladmsgh34/gwangcheon-shop \
+            --repo "$TARGET_REPO" \
             --state merged --limit $LIMIT \
             --json number,title,mergedAt,additions,deletions \
             > /tmp/prs.json
@@ -196,7 +201,7 @@ jobs:
 
           d = json.load(open('/tmp/report.json'))
           date = os.environ.get('REPORT_DATE', datetime.now().strftime('%Y-%m-%d'))
-          repo = "rladmsgh34/gwangcheon-shop"
+          repo = os.environ.get('TARGET_REPO', 'unknown')
 
           patterns_path = Path("data/diff-patterns.json")
           existing = json.loads(patterns_path.read_text()) if patterns_path.exists() else {"patterns": []}
@@ -232,6 +237,7 @@ jobs:
           PYEOF
         env:
           REPORT_DATE: ${{ steps.analyze.outputs.date }}
+          TARGET_REPO: ${{ env.TARGET_REPO }}
 
       - name: 히스토리 파일 커밋
         run: |
@@ -249,7 +255,7 @@ jobs:
         run: |
           python3 src/patch_claude_md.py \
             --report /tmp/report.json \
-            --claude-md gwangcheon-shop/CLAUDE.md \
+            --claude-md target-repo/CLAUDE.md \
             --date "${{ steps.analyze.outputs.date }}" \
             ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} \
             2>&1 | tee /tmp/patch-log.txt
@@ -261,12 +267,12 @@ jobs:
           fi
 
       # ── Step 4b: open PR (only when dry_run=false and changes exist) ────────
-      - name: Open gwangcheon-shop PR
+      - name: Open target repo PR
         if: steps.patch.outputs.has_changes == 'true' && inputs.dry_run != 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_PAT }}
-          path: gwangcheon-shop
+          path: target-repo
           commit-message: "chore: AI Dev Loop 자동 규칙 업데이트 (${{ steps.analyze.outputs.date }})"
           branch: chore/ai-loop-rules-${{ steps.analyze.outputs.date }}
           title: "🤖 CLAUDE.md 규칙 업데이트 (${{ steps.analyze.outputs.date }})"

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -163,20 +163,23 @@ def load_analysis_cache() -> list[dict]:
     except Exception:
         return []
 
+    repo_full = data.get("repo", "unknown")
+    repo_short = repo_full.split("/")[-1] if "/" in repo_full else repo_full
+
     chunks = []
     summary = data.get("summary", {})
     if summary:
         chunks.append({
-            "id": "cache_summary",
+            "id": f"cache_summary_{repo_short}",
             "text": (
-                f"gwangcheon-shop 최신 분석: "
+                f"{repo_short} 최신 분석: "
                 f"총 PR {summary.get('total_prs', '?')}개, "
                 f"fix PR {summary.get('fix_prs', '?')}개, "
                 f"fix율 {summary.get('fix_rate', '?')}%."
             ),
             "metadata": {
                 "type": "project_summary",
-                "repo": "gwangcheon-shop",
+                "repo": repo_short,
                 "fix_rate": summary.get("fix_rate", 0),
                 "date": data.get("analyzed_at", ""),
             },
@@ -184,9 +187,9 @@ def load_analysis_cache() -> list[dict]:
 
     for cluster in data.get("clusters", []):
         chunks.append({
-            "id": f"cache_cluster_{cluster.get('start', 0)}_{cluster.get('end', 0)}",
+            "id": f"cache_cluster_{repo_short}_{cluster.get('start', 0)}_{cluster.get('end', 0)}",
             "text": (
-                f"gwangcheon-shop 회귀 클러스터: "
+                f"{repo_short} 회귀 클러스터: "
                 f"{cluster.get('domain', 'unknown')} 도메인에서 "
                 f"#{cluster.get('start')} ~ #{cluster.get('end')} "
                 f"({cluster.get('size', '?')}개 연속 fix PR)."
@@ -194,7 +197,7 @@ def load_analysis_cache() -> list[dict]:
             "metadata": {
                 "type": "cluster",
                 "domain": cluster.get("domain", ""),
-                "repo": "gwangcheon-shop",
+                "repo": repo_short,
                 "date": data.get("analyzed_at", ""),
             },
         })


### PR DESCRIPTION
## 변경 사항

### 목표
`evolve-rules.yml`과 `rag/ingest.py`에 박혀 있던 `rladmsgh34/gwangcheon-shop` 하드코딩을 제거해 어떤 레포에서도 사용할 수 있게 범용화.

### evolve-rules.yml

**TARGET_REPO 우선순위:**
```
inputs.target_repo (workflow_dispatch 입력)
  → vars.TARGET_REPO (레포 Variables 설정)
  → fallback: rladmsgh34/gwangcheon-shop
```

| 변경 전 | 변경 후 |
|---------|---------|
| `rladmsgh34/gwangcheon-shop` (하드코딩) | `${{ env.TARGET_REPO }}` |
| checkout path: `gwangcheon-shop` | `target-repo` (고정 generic 경로) |
| diff-patterns step의 `repo = "rladmsgh34/gwangcheon-shop"` | `repo = os.environ.get('TARGET_REPO')` |

### rag/ingest.py

`load_analysis_cache()`에서 `"gwangcheon-shop"` 하드코딩 → `data["repo"]` 필드에서 읽도록 변경.  
chunk ID에 repo_short 포함해 다중 프로젝트 데이터 충돌 방지.

## 다른 프로젝트에서 사용하는 방법

1. ai-dev-loop-analyzer fork 또는 직접 설치
2. 레포 Settings → Variables → `TARGET_REPO = owner/your-repo` 추가
3. `GH_PAT` secret 추가 (target repo checkout + PR 생성 권한)
4. `evolve-rules.yml` workflow 실행

## 테스트
- [x] YAML 구문 검사 통과
- [x] `python3 -c "import ast; ast.parse(...)"` 통과
- [x] `grep gwangcheon src/ .github/ -r` → 잔여 참조 없음 (도구 자체 URL 제외)