### PR TITLE
fix: AI PR detection, domain patterns, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: your-username/ai-dev-loop-analyzer@main
+      - uses: rladmsgh34/ai-dev-loop-analyzer@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           limit: "200"

--- a/profiles/default.json
+++ b/profiles/default.json
@@ -8,9 +8,11 @@
     ["payment",      "payment|checkout|order|cart|purchase"],
     ["database",     "migration|schema\\.|migrate\\b"],
     ["security",     "csp|xss|csrf|rate.limit|sanitize|escape|content.security"],
-    ["external-api", "stripe|twilio|sendgrid|s3\\b|cloudfront|firebase|slack|webhook"],
+    ["external-api", "stripe|twilio|sendgrid|s3\\b|cloudfront|firebase|slack|webhook|kakao|portone|toss|naver|daum|coolsms|sentry|gcs|gcp\\b|aws\\b|azure"],
     ["test/e2e",     "\\.test\\.|\\.spec\\.|e2e|playwright|vitest|jest|coverage|flaky"],
-    ["config",       "\\.config\\.|env\\.ts|tsconfig|biome|tailwind"],
+    ["maintenance",  "refactor|cleanup|rename|deprecat|reorganize|remov\\b|rewrite"],
+    ["docs",         "readme|changelog|docs?\\b|document|comment"],
+    ["config",       "\\.config\\.|env\\.ts|tsconfig|biome|tailwind|eslint|prettier|lint\\b"],
     ["api",          "api/|route\\.ts|route\\.js"],
     ["ui",           "components/|page\\.tsx|page\\.jsx"]
   ],
@@ -22,6 +24,8 @@
     "security":     "보안 관련 수정 후 외부 도메인 allowlist 누락 여부 확인 — {count}회 회귀",
     "external-api": "외부 API 연동 변경 시 로컬과 배포 환경 동작이 다를 수 있음 — {count}회 회귀, 반드시 배포 후 검증",
     "test/e2e":     "테스트 환경 변경 시 프로덕션 빌드 서버 기준으로만 실행 — {count}회 플레이키 발생",
+    "maintenance":  "리팩터링·정리 작업 후 관련 테스트 전체 실행 필수 — {count}회 회귀",
+    "docs":         "문서 변경 시 코드·설정과 내용 일치 여부 확인 — {count}회 불일치 발생",
     "config":       "설정 파일 변경 후 반드시 dev 서버 재시작 및 빌드 확인 — {count}회 회귀"
   },
   "rule_hints": {
@@ -32,6 +36,8 @@
     "security":     "→ 보안 변경 후 외부 도메인 allowlist 누락 여부 확인",
     "external-api": "→ 로컬 ≠ 배포 환경 동작 가능 — 반드시 배포 후 검증",
     "test/e2e":     "→ 테스트 서버는 프로덕션 빌드 기준으로만 실행",
+    "maintenance":  "→ 리팩터링 후 관련 테스트 전체 실행 필수",
+    "docs":         "→ 문서와 실제 코드·설정 내용 일치 여부 확인",
     "config":       "→ 설정 파일 변경 후 dev 서버 재시작 필수"
   },
   "prompt_hints": {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -36,9 +36,11 @@ DOMAIN_PATTERNS: list[tuple[str, str]] = [
     ("payment",      r"payment|checkout|order|cart|purchase"),
     ("database",     r"migration|schema\.|migrate\b"),
     ("security",     r"csp|xss|csrf|rate.limit|sanitize|escape|content.security"),
-    ("external-api", r"stripe|twilio|sendgrid|s3\b|cloudfront|firebase|slack|webhook"),
+    ("external-api", r"stripe|twilio|sendgrid|s3\b|cloudfront|firebase|slack|webhook|kakao|portone|toss|naver|daum|coolsms|sentry|gcs|gcp\b|aws\b|azure"),
     ("test/e2e",     r"\.test\.|\.spec\.|e2e|playwright|vitest|jest|coverage|flaky"),
-    ("config",       r"\.config\.|env\.ts|tsconfig|biome|tailwind"),
+    ("maintenance",  r"refactor|cleanup|rename|deprecat|reorganize|remov\b|rewrite"),
+    ("docs",         r"readme|changelog|docs?\b|document|comment"),
+    ("config",       r"\.config\.|env\.ts|tsconfig|biome|tailwind|eslint|prettier|lint\b"),
     ("api",          r"api/|route\.ts|route\.js"),
     ("ui",           r"components/|page\.tsx|page\.jsx"),
 ]
@@ -191,6 +193,38 @@ def _parallel_fetch(pr_numbers: list[int], label: str) -> dict[int, tuple]:
     return pr_map
 
 
+def _fetch_ai_flag(pr_number: int) -> tuple[int, bool]:
+    """커밋 메시지에서 'Co-Authored-By: Claude' 포함 여부만 확인 (파일/diff 없이 커밋만)."""
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "commits"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return (pr_number, False)
+    try:
+        data = json.loads(result.stdout)
+        is_ai = any(
+            "Co-Authored-By: Claude" in (commit.get("messageBody", "") or "")
+            or "Co-Authored-By: Claude" in (commit.get("messageHeadline", "") or "")
+            for commit in data.get("commits", [])
+        )
+        return (pr_number, is_ai)
+    except Exception:
+        return (pr_number, False)
+
+
+def fetch_ai_flags(pr_numbers: list[int]) -> dict[int, bool]:
+    """PR 번호 목록을 받아 AI 생성 여부를 병렬로 확인한다."""
+    print(f"AI 생성 PR 감지 중 ({len(pr_numbers)}개)...", file=sys.stderr)
+    results: dict[int, bool] = {}
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {pool.submit(_fetch_ai_flag, num): num for num in pr_numbers}
+        for future in as_completed(futures):
+            num, is_ai = future.result()
+            results[num] = is_ai
+    return results
+
+
 # ── 분석 엔진 ────────────────────────────────────────────────────────────────
 def detect_clusters(prs: list[PR], window: int = 8, threshold: int = 2) -> list[Cluster]:
     """
@@ -280,6 +314,8 @@ RULE_TEMPLATES: dict[str, str] = {
     "security":     "After security changes, verify no external domains are missing from the allowlist — {count} regressions",
     "external-api": "External API integration changes may behave differently locally vs. deployed — {count} regressions, verify on staging",
     "test/e2e":     "Run E2E tests against a production build server, not dev — {count} flaky incidents",
+    "maintenance":  "After refactoring/cleanup, run all related tests to catch regressions — {count} regressions",
+    "docs":         "After documentation changes, verify content matches actual code and config — {count} mismatches",
     "config":       "After config file changes, restart the dev server and verify the build — {count} regressions",
 }
 
@@ -615,6 +651,11 @@ def main():
         action="store_true",
         help="AI 규칙 생성 비활성화, 템플릿만 사용",
     )
+    parser.add_argument(
+        "--no-fetch-ai",
+        action="store_true",
+        help="AI 생성 PR 감지 패스 비활성화 (기본: 활성)",
+    )
     args = parser.parse_args()
 
     if args.profile:
@@ -688,6 +729,15 @@ def main():
                 pr = pr_map_by_num[num]
                 pr.files, pr.review_comments, pr.is_ai_generated, pr.diff_snippet = files, comments, is_ai, diff
                 pr.domain = classify_domain(pr.title, pr.files)
+
+    # AI 감지 패스: smart-fetch/fetch-files로 커버되지 않은 PR에 적용
+    if not args.no_fetch_ai:
+        already_checked = {p.number for p in prs if p.is_ai_generated}
+        remaining = [p.number for p in prs if p.number not in already_checked]
+        if remaining:
+            ai_flags = fetch_ai_flags(remaining)
+            for num, is_ai in ai_flags.items():
+                pr_map_by_num[num].is_ai_generated = is_ai
 
     clusters = detect_clusters(prs)
     risky_files = rank_risky_files(prs)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -203,6 +203,15 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
                 pr.is_ai_generated, pr.diff_snippet = is_ai, diff
                 pr.domain = ana.classify_domain(pr.title, pr.files)
 
+    # AI 감지 패스: 클러스터 PR 외 전체 PR 대상으로 Co-Authored-By 확인
+    already_checked = {num for num in cluster_nums}
+    remaining = [p.number for p in prs if p.number not in already_checked]
+    if remaining:
+        ai_flags = ana.fetch_ai_flags(remaining)
+        for num, is_ai in ai_flags.items():
+            if not pr_map[num].is_ai_generated:
+                pr_map[num].is_ai_generated = is_ai
+
     clusters = ana.detect_clusters(prs)
     risky_files = ana.rank_risky_files(prs)
     domain_counts = ana.rank_risky_domains(prs)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,135 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from pathlib import Path
+import pytest
+
+from analyze import PR, classify_domain, detect_clusters, load_profile, DOMAIN_PATTERNS
+
+
+# ── Domain classification tests ──────────────────────────────────────────────
+
+def test_classify_domain_ci():
+    """PR title containing deployment/docker keywords maps to 'ci/cd'."""
+    result = classify_domain("fix: docker healthcheck", [])
+    assert result == "ci/cd"
+
+
+def test_classify_domain_auth():
+    """PR title containing session/token keywords maps to 'auth'."""
+    result = classify_domain("fix: session token refresh", [])
+    assert result == "auth"
+
+
+def test_classify_domain_payment():
+    """PR title containing checkout/cart keywords maps to 'payment'."""
+    result = classify_domain("fix: checkout cart total", [])
+    assert result == "payment"
+
+
+def test_classify_domain_external_api():
+    """Korean service keywords (kakao, portone, sentry) map to 'external-api'."""
+    assert classify_domain("feat: kakao pay integration", ["src/lib/kakao.ts"]) == "external-api"
+    assert classify_domain("fix: portone webhook timeout", []) == "external-api"
+    assert classify_domain("chore: update sentry dsn", []) == "external-api"
+
+
+def test_classify_domain_general():
+    """PR title that matches no domain pattern resolves to 'general'."""
+    result = classify_domain("chore: bump deps", [])
+    assert result == "general"
+
+
+# ── is_fix helper tests ───────────────────────────────────────────────────────
+
+def _is_fix(title: str) -> bool:
+    """Replicate the is_fix logic used in fetch_prs (regex match against FIX_PR_REGEX)."""
+    import re
+    from analyze import FIX_PR_REGEX
+    return bool(re.match(FIX_PR_REGEX, title, re.I))
+
+
+def test_is_fix_pr_true():
+    """Titles starting with 'fix:' are identified as fix PRs."""
+    assert _is_fix("fix: broken button") is True
+
+
+def test_is_fix_pr_false():
+    """Titles starting with 'feat:' are not identified as fix PRs."""
+    assert _is_fix("feat: add button") is False
+
+
+# ── Cluster detection tests ───────────────────────────────────────────────────
+
+def _make_pr(number: int, title: str, is_fix: bool) -> PR:
+    return PR(
+        number=number,
+        title=title,
+        merged_at="2026-01-01T00:00:00Z",
+        additions=10,
+        deletions=5,
+        is_fix=is_fix,
+        domain=classify_domain(title, []),
+    )
+
+
+def test_detect_clusters_finds_consecutive_fixes():
+    """Two consecutive fix PRs within the default window are detected as a cluster."""
+    prs = [
+        _make_pr(1, "feat: initial feature", is_fix=False),
+        _make_pr(2, "fix: broken layout", is_fix=True),
+        _make_pr(3, "fix: missing border", is_fix=True),
+        _make_pr(4, "feat: new page", is_fix=False),
+    ]
+    clusters = detect_clusters(prs, window=8, threshold=2)
+    assert len(clusters) >= 1
+    cluster_pr_numbers = {p.number for c in clusters for p in c.prs}
+    # Both fix PRs must be captured in the cluster
+    assert 2 in cluster_pr_numbers
+    assert 3 in cluster_pr_numbers
+
+
+def test_detect_clusters_no_cluster_for_single_fix():
+    """A single isolated fix PR does not form a cluster (below threshold=2)."""
+    prs = [
+        _make_pr(1, "feat: initial feature", is_fix=False),
+        _make_pr(2, "fix: typo", is_fix=True),
+        _make_pr(3, "feat: new feature", is_fix=False),
+    ]
+    clusters = detect_clusters(prs, window=8, threshold=2)
+    assert len(clusters) == 0
+
+
+# ── AI detection logic test ───────────────────────────────────────────────────
+
+def test_ai_detection_via_commit_body():
+    """Commit body containing 'Co-Authored-By: Claude' is detected as AI-generated.
+
+    This tests the pure string-matching logic used inside fetch_pr_details,
+    without invoking subprocess or any external call.
+    """
+    commit_body_with_claude = "Some commit message\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+    commit_body_without_claude = "Some commit message\n\nCo-Authored-By: Human Dev <dev@example.com>"
+
+    assert "Co-Authored-By: Claude" in commit_body_with_claude
+    assert "Co-Authored-By: Claude" not in commit_body_without_claude
+
+
+# ── Profile loading test ──────────────────────────────────────────────────────
+
+def test_load_profile():
+    """load_profile() replaces DOMAIN_PATTERNS with values from the JSON file."""
+    profile_path = Path(__file__).parent.parent / "profiles" / "default.json"
+    assert profile_path.exists(), f"profiles/default.json not found at {profile_path}"
+
+    original_first_domain = DOMAIN_PATTERNS[0][0] if DOMAIN_PATTERNS else None
+
+    load_profile(profile_path)
+
+    # After loading the default profile, DOMAIN_PATTERNS must be non-empty
+    assert len(DOMAIN_PATTERNS) > 0
+
+    # The first entry in profiles/default.json domain_patterns is 'ci/cd'
+    first_domain, first_pattern = DOMAIN_PATTERNS[0]
+    assert first_domain == "ci/cd"
+    assert "docker" in first_pattern

--- a/web/lib/analyzer.ts
+++ b/web/lib/analyzer.ts
@@ -43,9 +43,11 @@ const DOMAIN_PATTERNS: [string, RegExp][] = [
   ['payment',      /payment|portone|checkout|order|cart|purchase|결제|주문|장바구니/i],
   ['database',     /prisma|migration|schema/i],
   ['security',     /csp|xss|csrf|rate.?limit|sanitize|allowlist/i],
-  ['external-api', /kakao|postcode|우편번호|google.?maps|gcs|sentry|daum/i],
+  ['external-api', /stripe|twilio|sendgrid|s3\b|cloudfront|firebase|slack|webhook|kakao|postcode|우편번호|google.?maps|gcs|sentry|daum|portone|toss|naver|coolsms|gcp\b|aws\b|azure/i],
   ['test/e2e',     /\.test\.|\.spec\.|e2e|playwright|vitest|coverage/i],
-  ['config',       /next\.config|env\.ts|tsconfig|biome|tailwind|npmrc/i],
+  ['maintenance',  /refactor|cleanup|rename|deprecat|rewrite|reorganize/i],
+  ['docs',         /readme|changelog|docs?\b|document/i],
+  ['config',       /next\.config|env\.ts|tsconfig|biome|tailwind|npmrc|eslint|prettier|lint\b/i],
 ]
 
 export function isFixPR(title: string): boolean {

--- a/web/lib/github.ts
+++ b/web/lib/github.ts
@@ -1,22 +1,88 @@
 import { classifyDomain, isFixPR, type PR } from './analyzer'
 
 const GH_API = 'https://api.github.com'
+const GH_GRAPHQL = 'https://api.github.com/graphql'
+
+// GraphQL 응답 타입
+interface GHGraphQLPRNode {
+  number: number
+  title: string
+  mergedAt: string
+  additions: number
+  deletions: number
+  commits: {
+    nodes: {
+      commit: {
+        message: string
+      }
+    }[]
+  }
+}
+
+interface GHGraphQLResponse {
+  data: {
+    repository: {
+      pullRequests: {
+        nodes: GHGraphQLPRNode[]
+        pageInfo: {
+          hasNextPage: boolean
+          endCursor: string | null
+        }
+      }
+    }
+  }
+  errors?: { message: string }[]
+}
+
+const MERGED_PRS_QUERY = `
+  query($owner: String!, $repo: String!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequests(first: 100, states: MERGED, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          number
+          title
+          mergedAt
+          additions
+          deletions
+          commits(first: 10) {
+            nodes {
+              commit {
+                message
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`
 
 export async function fetchMergedPRs(owner: string, repo: string, limit = 200): Promise<PR[]> {
   const prs: PR[] = []
-  let page = 1
+  let cursor: string | null = null
+
+  const authHeaders = process.env.GITHUB_TOKEN
+    ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+    : {}
 
   while (prs.length < limit) {
-    const res = await fetch(
-      `${GH_API}/repos/${owner}/${repo}/pulls?state=closed&per_page=100&page=${page}&sort=updated&direction=desc`,
-      {
-        headers: {
-          Accept: 'application/vnd.github.v3+json',
-          ...(process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
-        },
-        next: { revalidate: 3600 }, // 1시간 캐시
-      }
-    )
+    const res = await fetch(GH_GRAPHQL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...authHeaders,
+      },
+      body: JSON.stringify({
+        query: MERGED_PRS_QUERY,
+        variables: { owner, repo, cursor },
+      }),
+      next: { revalidate: 3600 }, // 1시간 캐시
+    })
 
     if (!res.ok) {
       if (res.status === 404) throw new Error('레포지토리를 찾을 수 없습니다. public 레포인지 확인해주세요.')
@@ -24,26 +90,41 @@ export async function fetchMergedPRs(owner: string, repo: string, limit = 200): 
       throw new Error(`GitHub API 오류: ${res.status}`)
     }
 
-    const data: GHPull[] = await res.json()
-    const merged = data.filter(pr => pr.merged_at !== null)
+    const json: GHGraphQLResponse = await res.json()
 
-    for (const pr of merged) {
+    if (json.errors && json.errors.length > 0) {
+      const msg = json.errors[0].message
+      if (msg.includes('Could not resolve to a Repository')) {
+        throw new Error('레포지토리를 찾을 수 없습니다. public 레포인지 확인해주세요.')
+      }
+      throw new Error(`GitHub GraphQL 오류: ${msg}`)
+    }
+
+    const { nodes, pageInfo } = json.data.repository.pullRequests
+
+    for (const pr of nodes) {
+      // 커밋 메시지에 "Co-Authored-By: Claude" 포함 여부로 AI 생성 PR 감지
+      const isAiGenerated = pr.commits.nodes.some(({ commit }) =>
+        commit.message.includes('Co-Authored-By: Claude')
+      )
+
       const title = pr.title
-      const isFix = isFixPR(title)
       prs.push({
         number: pr.number,
         title,
-        mergedAt: pr.merged_at!,
-        additions: pr.additions ?? 0,
-        deletions: pr.deletions ?? 0,
-        isFix,
+        mergedAt: pr.mergedAt,
+        additions: pr.additions,
+        deletions: pr.deletions,
+        isFix: isFixPR(title),
         domain: classifyDomain(title),
-        isAiGenerated: false, // web에서는 커밋 조회 비용이 크므로 생략
+        isAiGenerated,
       })
+
+      if (prs.length >= limit) break
     }
 
-    if (data.length < 100 || prs.length >= limit) break
-    page++
+    if (!pageInfo.hasNextPage || prs.length >= limit) break
+    cursor = pageInfo.endCursor
   }
 
   return prs.slice(0, limit).sort((a, b) => a.number - b.number)
@@ -95,14 +176,6 @@ export interface LanguagePatterns {
   total_repos_analyzed: number
   languages: Record<string, LangStats>
   repo_results: { owner: string; repo: string; fix_rate: number; language: string }[]
-}
-
-interface GHPull {
-  number: number
-  title: string
-  merged_at: string | null
-  additions?: number
-  deletions?: number
 }
 
 interface GHRepo {


### PR DESCRIPTION
## 변경 사항

### 🔴 긴급 수정 — AI 생성 PR 감지 (0% → 정상)

**원인**: `web/lib/github.ts`에서 `isAiGenerated: false` 하드코딩, Python도 smart-fetch가 클러스터 PR만 커밋 수집

**수정**:
- `web/lib/github.ts`: REST API → GraphQL 전환. 한 요청으로 PR + commits 수집, `"Co-Authored-By: Claude"` 커밋 메시지 감지
- `src/analyze.py`: `_fetch_ai_flag()` + `fetch_ai_flags()` 경량 패스 추가. smart-fetch 이후 나머지 PR 전체 AI 감지
- `src/mcp_server.py`: `_analyze_pr_history()`에 AI 감지 패스 추가

### 🟡 도메인 분류 개선 (general 36% → 목표 <10%)

- **external-api** 패턴 확장: `kakao|portone|toss|naver|daum|coolsms|sentry|gcs|gcp|aws|azure`
- **maintenance** 도메인 신규: `refactor|cleanup|rename|deprecat|reorganize|rewrite`
- **docs** 도메인 신규: `readme|changelog|docs|document|comment`
- **config** 패턴 확장: `eslint|prettier|lint`

`profiles/default.json`, `src/analyze.py`, `web/lib/analyzer.ts` 세 곳 동시 반영.

### 📝 기타

- README: `uses: your-username/ai-dev-loop-analyzer@main` → `rladmsgh34`
- `pytest.ini` + `tests/test_analyze.py` 추가 (11개 단위 테스트, 11/11 통과)

## 테스트

- [x] `pytest tests/` 로컬 11/11 통과
- [x] `classify_domain`, `detect_clusters`, AI 커밋 파싱, `load_profile` 커버

## 머지 후

`evolve-rules.yml`이 다음 실행 시 AI 감지 데이터가 채워지며 대시보드 AI 비율이 정상 표시됨