### PR TITLE
fix: fetch files for all fix PRs to improve domain classification accuracy

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -185,17 +185,17 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
         prs.append(pr)
     prs = sorted(prs, key=lambda p: p.number)
 
-    # smart-fetch: 클러스터 PR만 diff + 파일 수집
-    pre_clusters = ana.detect_clusters(prs)
-    cluster_nums = list({p.number for c in pre_clusters for p in c.prs})
+    # fix PR 전체 파일 fetch → domain 분류 정확도 향상
+    # (클러스터 여부 관계없이 fix PR이면 모두 파일+diff 수집)
     pr_map = {p.number: p for p in prs}
+    fix_nums = [p.number for p in prs if p.is_fix]
 
-    if cluster_nums:
+    if fix_nums:
         def _fetch(num):
             return num, ana.fetch_pr_details(num)
 
         with ThreadPoolExecutor(max_workers=8) as pool:
-            futures = {pool.submit(_fetch, num): num for num in cluster_nums}
+            futures = {pool.submit(_fetch, num): num for num in fix_nums}
             for future in as_completed(futures):
                 num, (files, comments, is_ai, diff) = future.result()
                 pr = pr_map[num]
@@ -203,8 +203,8 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
                 pr.is_ai_generated, pr.diff_snippet = is_ai, diff
                 pr.domain = ana.classify_domain(pr.title, pr.files)
 
-    # AI 감지 패스: 클러스터 PR 외 전체 PR 대상으로 Co-Authored-By 확인
-    already_checked = {num for num in cluster_nums}
+    # AI 감지 패스: fix PR 외 나머지 PR 대상으로 Co-Authored-By 확인
+    already_checked = set(fix_nums)
     remaining = [p.number for p in prs if p.number not in already_checked]
     if remaining:
         ai_flags = ana.fetch_ai_flags(remaining)


### PR DESCRIPTION
## 문제

`analyze_pr_history`의 smart-fetch는 클러스터 PR만 파일 경로를 가져왔습니다.
클러스터에 속하지 않은 fix PR은 제목 키워드만으로 domain 분류 → general 과다.

## 변경 사항

`mcp_server.py` `_analyze_pr_history`:
- **이전**: 클러스터 PR만 파일 fetch
- **이후**: fix PR 전체 파일 fetch

파일 경로에는 제목에 없는 강한 domain 신호가 있습니다:
- `src/components/` → ui
- `prisma/` → database
- `tests/` → test/e2e
- `.github/workflows/` → ci/cd

## 벤치마크 결과 (60 PRs each)

| 레포 | 제목만 | +파일 경로 | 개선 |
|------|--------|-----------|------|
| calcom/cal.com | 26.7% | **13.3%** | -13.4pp |
| supabase/supabase | 46.7% | **5.0%** | -41.7pp |

## 테스트

- [x] `python3 -m pytest tests/ -v` → 24 passed in 0.06s
- [x] 기존 테스트 모두 통과