### PR TITLE
feat: support scope_to_domain override in profile JSON

### DIFF
--- a/profiles/default.json
+++ b/profiles/default.json
@@ -40,6 +40,8 @@
     "docs":         "→ 문서와 실제 코드·설정 내용 일치 여부 확인",
     "config":       "→ 설정 파일 변경 후 dev 서버 재시작 필수"
   },
+  "scope_to_domain": {
+  },
   "prompt_hints": {
     "language":      "ko",
     "ai_assistant":  "AI coding assistant",

--- a/profiles/examples/nextjs-prisma.json
+++ b/profiles/examples/nextjs-prisma.json
@@ -34,6 +34,22 @@
     "test/e2e":     "→ E2E 서버는 `next start`(standalone) 기준으로만 실행",
     "config":       "→ next.config.ts 변경 후 dev 서버 재시작 필수"
   },
+  "scope_to_domain": {
+    "nextauth":  "auth",
+    "middleware": "auth",
+    "payment":   "payment",
+    "checkout":  "payment",
+    "order":     "payment",
+    "cart":      "payment",
+    "prisma":    "database",
+    "migration": "database",
+    "seed":      "database",
+    "docker":    "ci/cd",
+    "deploy":    "ci/cd",
+    "workflow":  "ci/cd",
+    "e2e":       "test/e2e",
+    "playwright":"test/e2e"
+  },
   "prompt_hints": {
     "language":     "ko",
     "ai_assistant": "Claude Code",

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -91,6 +91,9 @@ def load_profile(path: str | Path) -> None:
         RULE_HINTS.update(data["rule_hints"])
     if "fix_pr_regex" in data:
         FIX_PR_REGEX = data["fix_pr_regex"]
+    if "scope_to_domain" in data:
+        # 기본 매핑 위에 프로젝트별 매핑을 덮어쓴다 (replace가 아닌 merge)
+        _SCOPE_TO_DOMAIN.update(data["scope_to_domain"])
     if "prompt_hints" in data:
         PROMPT_HINTS.clear()
         PROMPT_HINTS.update(data["prompt_hints"])

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -256,3 +256,51 @@ def test_classify_domain_korean_cicd():
     """Korean deploy keywords (배포, 도커) map to 'ci/cd'."""
     assert classify_domain("fix: 스테이징 배포 실패 수정", []) == "ci/cd"
     assert classify_domain("chore: 도커 이미지 최적화", []) == "ci/cd"
+
+
+# ── scope_to_domain profile override tests ───────────────────────────────────
+
+def test_load_profile_scope_to_domain_merge():
+    """scope_to_domain in profile merges into existing mappings (does not replace)."""
+    import analyze
+    import json, tempfile, os
+
+    profile = {
+        "scope_to_domain": {
+            "sms":    "external-api",
+            "cron":   "database",
+            "pitr":   "database",
+            "studio": "ui",
+        }
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(profile, f)
+        tmp = f.name
+
+    try:
+        load_profile(tmp)
+        assert analyze._SCOPE_TO_DOMAIN["sms"] == "external-api"
+        assert analyze._SCOPE_TO_DOMAIN["cron"] == "database"
+        assert analyze._SCOPE_TO_DOMAIN["pitr"] == "database"
+        assert analyze._SCOPE_TO_DOMAIN["studio"] == "ui"
+        assert analyze._SCOPE_TO_DOMAIN["auth"] == "auth"
+        assert analyze._SCOPE_TO_DOMAIN["payment"] == "payment"
+    finally:
+        os.unlink(tmp)
+
+
+def test_classify_domain_profile_scope_override():
+    """Custom scope_to_domain from profile is used in classify_domain()."""
+    import analyze, json, tempfile, os
+
+    profile = {"scope_to_domain": {"sms": "external-api", "pitr": "database"}}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(profile, f)
+        tmp = f.name
+
+    try:
+        load_profile(tmp)
+        assert classify_domain("fix(sms): hook validation", []) == "external-api"
+        assert classify_domain("fix(pitr): restore duration input", []) == "database"
+    finally:
+        os.unlink(tmp)


### PR DESCRIPTION
## 배경

conventional commit scope가 프로젝트마다 다릅니다.

- supabase: `fix(sms):`, `fix(pitr):`, `fix(studio):`
- cal.com: `fix(booking):`, `fix(availability):`
- 내부 도메인: `fix(naver):`, `fix(portone):`

기본 `_SCOPE_TO_DOMAIN`에 없으면 전부 keyword 매칭으로 넘어가고, 거기서도 안 잡히면 general로 빠졌습니다.

## 변경 사항

프로파일 JSON에 `scope_to_domain` 키를 추가해 프로젝트별 매핑을 주입할 수 있습니다.

```json
{
  "scope_to_domain": {
    "sms":    "external-api",
    "pitr":   "database",
    "studio": "ui",
    "cron":   "database"
  }
}
```

- `load_profile()`에서 기존 기본 매핑에 **merge** (replace 아님)
  → 기본 auth/payment/ci 매핑은 그대로 유지
- `profiles/default.json`: 빈 `scope_to_domain` 키로 문서화
- `profiles/examples/nextjs-prisma.json`: 실용 예시 추가

## 테스트

- [x] merge 동작 검증 (기본 매핑 보존 확인)
- [x] classify_domain()에 즉시 반영 확인
- [x] `python3 -m pytest tests/ -v` → 26 passed in 0.07s