### PR TITLE
feat: v*.*.* 태그 push 시 자동 릴리스 생성

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 전체 태그 히스토리 필요
+
+      - name: Get previous tag
+        id: prev_tag
+        run: |
+          CURRENT_TAG="${GITHUB_REF_NAME}"
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+          echo "prev_tag=${PREV_TAG:-}" >> "$GITHUB_OUTPUT"
+          echo "current_tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: notes
+        env:
+          CURRENT_TAG: ${{ steps.prev_tag.outputs.current_tag }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
+        run: |
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="${PREV_TAG}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
+          # 커밋 목록을 feat/fix/chore로 분류
+          FEAT=$(git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges | grep -E "^- feat(\(.+\))?:" || true)
+          FIX=$(git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges | grep -E "^- fix(\(.+\))?:" || true)
+          CHORE=$(git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges | grep -E "^- chore(\(.+\))?:" || true)
+          OTHER=$(git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges | grep -Ev "^- (feat|fix|chore)(\(.+\))?:" || true)
+
+          NOTES=""
+
+          if [ -n "$FEAT" ]; then
+            NOTES="${NOTES}### New Features\n${FEAT}\n\n"
+          fi
+          if [ -n "$FIX" ]; then
+            NOTES="${NOTES}### Bug Fixes\n${FIX}\n\n"
+          fi
+          if [ -n "$CHORE" ]; then
+            NOTES="${NOTES}### Chores\n${CHORE}\n\n"
+          fi
+          if [ -n "$OTHER" ]; then
+            NOTES="${NOTES}### Other Changes\n${OTHER}\n\n"
+          fi
+
+          if [ -z "$NOTES" ]; then
+            NOTES="No changes recorded."
+          fi
+
+          # 멀티라인 output 저장
+          {
+            echo "notes<<NOTES_EOF"
+            printf "%b" "$NOTES"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ steps.prev_tag.outputs.current_tag }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.notes }}
+        run: |
+          # alpha/beta/rc 태그이면 pre-release로 표시
+          PRERELEASE_FLAG=""
+          if echo "$CURRENT_TAG" | grep -qE "\-(alpha|beta|rc)"; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          BODY="## 변경 사항
+
+          ${RELEASE_NOTES}
+          ---
+          _[ai-dev-loop-analyzer](https://github.com/rladmsgh34/ai-dev-loop-analyzer)_"
+
+          # shellcheck disable=SC2086
+          gh release create "$CURRENT_TAG" \
+            --title "$CURRENT_TAG" \
+            --notes "$BODY" \
+            --verify-tag \
+            $PRERELEASE_FLAG


### PR DESCRIPTION
## Summary

- `v*.*.*` 태그를 push하면 `.github/workflows/release.yml`이 트리거되어 GitHub Release를 자동 생성합니다.
- 커밋 메시지를 `feat:` / `fix:` / `chore:` / 기타로 분류하여 구조화된 릴리스 노트를 생성합니다.
- 태그 이름에 `-alpha`, `-beta`, `-rc`가 포함되면 자동으로 pre-release로 표시합니다.
- `${{ }}` GHA 표현식은 `env:` 블록으로 분리하여 heredoc 치환 충돌을 방지했습니다.

## Test plan

- [ ] YAML 구문 검사 통과 (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] `v0.1.1` 등 버전 태그를 push하여 워크플로우 트리거 확인
- [ ] 릴리스 노트에 feat/fix/chore 섹션이 올바르게 분류되는지 확인
- [ ] `-alpha` / `-beta` 태그에서 pre-release 플래그가 붙는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)