### PR TITLE
feat: Claude Code hook CLI wrapper

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+ai-dev-loop-analyzer CLI 래퍼 — Claude Code PreToolUse 훅용
+
+사용법:
+  # Claude Code 훅에서 stdin으로 tool 정보를 수신
+  echo '{"tool_name":"Edit","tool_input":{"file_path":"/path/to/file"}}' | python3 cli.py
+
+  # 단독 테스트
+  python3 cli.py /path/to/file
+
+동작:
+  1. stdin JSON에서 tool_input.file_path 또는 tool_input.path를 추출
+  2. analysis-cache.json을 읽어 회귀 위험 파일 여부를 확인
+  3. 위험 있으면 stdout에 경고 출력 (Claude가 경고로 읽음)
+  4. 위험 없으면 조용히 종료 (exit 0, 출력 없음)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# 경로 설정
+SRC_DIR = Path(__file__).parent
+ROOT = SRC_DIR.parent
+CACHE_FILE = ROOT / "data" / "analysis-cache.json"
+
+sys.path.insert(0, str(SRC_DIR))
+
+
+def load_cache() -> dict:
+    """분석 캐시 로드. 캐시 없으면 빈 dict 반환."""
+    if CACHE_FILE.exists():
+        try:
+            return json.loads(CACHE_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def get_file_path_from_stdin() -> str | None:
+    """stdin JSON에서 파일 경로 추출. 실패 시 None 반환."""
+    if sys.stdin.isatty():
+        # 대화형 모드: stdin 없음
+        return None
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return None
+        data = json.loads(raw)
+        tool_input = data.get("tool_input", {})
+        # Edit/Write 모두 file_path 필드를 사용하지만 혹시 path도 체크
+        return tool_input.get("file_path") or tool_input.get("path")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def check_risk(file_path: str) -> str | None:
+    """
+    캐시에서 해당 파일의 위험도를 확인.
+    위험하면 경고 문자열 반환, 안전하면 None 반환.
+    """
+    cache = load_cache()
+    if not cache:
+        return None  # 캐시 없으면 조용히 통과
+
+    risky: dict[str, dict] = {
+        item["file"]: item for item in cache.get("risky_files", [])
+    }
+
+    # 정확히 일치하거나 접미사/접두사로 부분 매칭
+    match = risky.get(file_path) or next(
+        (v for k, v in risky.items() if file_path.endswith(k) or k.endswith(file_path)),
+        None,
+    )
+
+    if not match:
+        return None
+
+    domain = match.get("domain", "general")
+    count = match.get("fix_count", 0)
+    last_title = match.get("last_fix_title", "")
+    file_name = Path(file_path).name
+
+    lines = [f"[ai-dev-loop] {file_name} — {domain} 도메인에서 {count}회 수정 이력"]
+    if last_title:
+        lines.append(f"    마지막 fix: {last_title}")
+
+    return "\n".join(lines)
+
+
+def main():
+    # CLI 인수가 있으면 직접 파일 경로로 받음 (테스트용)
+    if len(sys.argv) > 1:
+        file_path = sys.argv[1]
+    else:
+        file_path = get_file_path_from_stdin()
+
+    if not file_path:
+        # 파일 경로를 특정할 수 없으면 조용히 통과
+        sys.exit(0)
+
+    warning = check_risk(file_path)
+    if warning:
+        print(warning)
+        # exit 0: Claude Code는 exit code가 아닌 stdout 내용으로 경고를 판단
+        sys.exit(0)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `src/cli.py` 추가: Claude Code PreToolUse 훅에서 호출되는 경량 CLI 래퍼
- Edit/Write 툴 실행 전 `data/analysis-cache.json`을 조회해 회귀 위험 파일 여부를 자동 경고
- MCP 패키지 의존 없이 캐시 파일만 직접 읽어 동작하므로 훅 환경에서도 안전하게 실행 가능

## 동작 방식

```
# Claude Code가 Edit 툴을 실행할 때 stdin으로 전달하는 JSON
{"tool_name":"Edit","tool_input":{"file_path":"src/lib/auth.ts"}}

# cli.py 출력 예시 (위험 파일인 경우)
[ai-dev-loop] auth.ts — auth 도메인에서 4회 수정 이력
    마지막 fix: fix: session token refresh

# 안전한 파일이면 아무것도 출력하지 않음 (exit 0)
```

## gwangcheon-shop 측 연동

gwangcheon-shop `.claude/settings.json`에 아래 훅 설정을 추가하는 별도 PR과 함께 동작합니다:

```json
{
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Edit|Write",
        "hooks": [{"type": "command", "command": "python3 /opt/.../wt-hook/src/cli.py"}]
      }
    ]
  }
}
```

## Test plan

- [x] `echo '{"tool_name":"Edit","tool_input":{"file_path":"src/lib/auth.ts"}}' | python3 src/cli.py` — 캐시에 있는 파일이면 경고 출력
- [x] 안전한 파일 경로 입력 시 출력 없이 exit 0
- [x] 캐시 파일 없을 때 조용히 통과 (exit 0)
- [x] `python3 src/cli.py /path/to/file` CLI 단독 실행도 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)