### PR TITLE
feat(analyze): replace PR-number window with 14-day time-window clustering

### DIFF
--- a/src/analyze.py
+++ b/src/analyze.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import subprocess
+from datetime import datetime, timezone, timedelta
 import urllib.request
 import urllib.error
 from collections import Counter, defaultdict
@@ -258,39 +259,63 @@ def fetch_ai_flags(pr_numbers: list[int]) -> dict[int, bool]:
 
 
 # ── 분석 엔진 ────────────────────────────────────────────────────────────────
-def detect_clusters(prs: list[PR], window: int = 8, threshold: int = 2) -> list[Cluster]:
+def detect_clusters(prs: list[PR], window: int = 14, threshold: int = 2) -> list[Cluster]:
     """
-    PR 번호 순서로 window 안에 fix가 threshold개 이상이면 클러스터.
-    겹치는 클러스터는 병합해 중복 제거.
+    mergedAt 기준 time-window(일) 내 fix PR이 threshold개 이상이면 클러스터.
+
+    window: 기준 PR로부터 몇 일 이내를 같은 클러스터로 볼지 (기본 14일)
+    threshold: 클러스터 최소 fix PR 수 (기본 2개)
+
+    날짜 순으로 정렬 후 greedy 슬라이딩 윈도우를 적용한다.
+    이미 클러스터에 포함된 PR은 다음 클러스터에서 제외해 중복을 방지한다.
+    merged_at 파싱 실패 시 epoch(2000-01-01)로 대체해 로버스트하게 동작한다.
     """
-    n = len(prs)
-    in_cluster: set[int] = set()  # 이미 클러스터에 포함된 PR index
-    clusters = []
+    _EPOCH = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
+    def _parse(s: str) -> datetime:
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except Exception:
+            return _EPOCH
+
+    # (원본 prs 인덱스, PR 객체, 파싱된 datetime) — fix PR만
+    fix_entries: list[tuple[int, PR, datetime]] = [
+        (i, p, _parse(p.merged_at)) for i, p in enumerate(prs) if p.is_fix
+    ]
+    fix_entries.sort(key=lambda x: x[2])  # 날짜 오름차순
+
+    in_cluster: set[int] = set()  # 원본 prs 인덱스
+    clusters: list[Cluster] = []
+    delta = timedelta(days=window)
+    n = len(fix_entries)
 
     i = 0
     while i < n:
-        if not prs[i].is_fix or i in in_cluster:
+        orig_i, pr_i, dt_i = fix_entries[i]
+        if orig_i in in_cluster:
             i += 1
             continue
-        # i에서 시작하는 window 수집
-        group_idx = [i]
-        j = i + 1
-        while j < n and prs[j].number - prs[i].number < window * 3:
-            if prs[j].is_fix:
-                group_idx.append(j)
-            j += 1
-            if len(group_idx) >= 8:  # 최대 클러스터 크기
-                break
 
-        if len(group_idx) >= threshold:
-            group = [prs[k] for k in group_idx]
-            domain = Counter(p.domain for p in group).most_common(1)[0][0]
-            clusters.append(Cluster(prs=group, domain=domain))
-            for k in group_idx:
-                in_cluster.add(k)
-            i = group_idx[-1] + 1
+        # i 기준 window 내 아직 미분류 fix PR 수집
+        group: list[tuple[int, PR]] = [(orig_i, pr_i)]
+        for j in range(i + 1, n):
+            orig_j, pr_j, dt_j = fix_entries[j]
+            if dt_j - dt_i > delta:
+                break  # 정렬됐으므로 이후도 전부 범위 밖
+            if orig_j not in in_cluster:
+                group.append((orig_j, pr_j))
+
+        if len(group) >= threshold:
+            group_prs = [p for _, p in group]
+            group_prs.sort(key=lambda p: p.number)  # start/end property 일관성
+            domain = Counter(p.domain for p in group_prs).most_common(1)[0][0]
+            clusters.append(Cluster(prs=group_prs, domain=domain))
+            for orig_k, _ in group:
+                in_cluster.add(orig_k)
+            i += len(group)  # 묶인 PR 수만큼 전진
         else:
             i += 1
+
     return clusters
 
 def rank_risky_files(prs: list[PR]) -> list[tuple[str, int]]:

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -304,3 +304,76 @@ def test_classify_domain_profile_scope_override():
         assert classify_domain("fix(pitr): restore duration input", []) == "database"
     finally:
         os.unlink(tmp)
+
+
+# ── Time-window clustering tests ─────────────────────────────────────────────
+
+def _make_pr_dated(number: int, title: str, is_fix: bool, merged_at: str) -> PR:
+    return PR(
+        number=number,
+        title=title,
+        merged_at=merged_at,
+        additions=10,
+        deletions=5,
+        is_fix=is_fix,
+        domain=classify_domain(title, []),
+    )
+
+
+def test_time_window_cluster_within_14_days():
+    """Two fix PRs merged 10 days apart are detected as a cluster (window=14)."""
+    prs = [
+        _make_pr_dated(1, "feat: feature", False, "2026-01-01T00:00:00Z"),
+        _make_pr_dated(2, "fix: auth bug", True,  "2026-01-05T00:00:00Z"),
+        _make_pr_dated(3, "fix: session",  True,  "2026-01-10T00:00:00Z"),
+        _make_pr_dated(4, "feat: page",    False, "2026-01-15T00:00:00Z"),
+    ]
+    clusters = detect_clusters(prs, window=14, threshold=2)
+    assert len(clusters) == 1
+    pr_nums = {p.number for p in clusters[0].prs}
+    assert pr_nums == {2, 3}
+
+
+def test_time_window_no_cluster_beyond_window():
+    """Two fix PRs merged 20 days apart are NOT a cluster when window=14."""
+    prs = [
+        _make_pr_dated(1, "fix: early bug", True, "2026-01-01T00:00:00Z"),
+        _make_pr_dated(2, "fix: late bug",  True, "2026-01-25T00:00:00Z"),
+    ]
+    clusters = detect_clusters(prs, window=14, threshold=2)
+    assert len(clusters) == 0
+
+
+def test_time_window_two_separate_clusters():
+    """Two independent time-window clusters in different periods are both detected."""
+    prs = [
+        _make_pr_dated(1, "fix: bug A1", True, "2026-01-01T00:00:00Z"),
+        _make_pr_dated(2, "fix: bug A2", True, "2026-01-03T00:00:00Z"),
+        _make_pr_dated(3, "feat: skip",  False, "2026-01-10T00:00:00Z"),
+        _make_pr_dated(4, "fix: bug B1", True, "2026-02-01T00:00:00Z"),
+        _make_pr_dated(5, "fix: bug B2", True, "2026-02-05T00:00:00Z"),
+    ]
+    clusters = detect_clusters(prs, window=14, threshold=2)
+    assert len(clusters) == 2
+    all_pr_nums = {p.number for c in clusters for p in c.prs}
+    assert all_pr_nums == {1, 2, 4, 5}
+
+
+def test_time_window_boundary_exact_14_days():
+    """Fix PR exactly window days apart is still included (boundary inclusive)."""
+    prs = [
+        _make_pr_dated(1, "fix: start", True, "2026-01-01T00:00:00Z"),
+        _make_pr_dated(2, "fix: end",   True, "2026-01-15T00:00:00Z"),  # exactly 14 days
+    ]
+    clusters = detect_clusters(prs, window=14, threshold=2)
+    assert len(clusters) == 1
+
+
+def test_time_window_malformed_date_fallback():
+    """PRs with unparseable merged_at are grouped together (epoch fallback)."""
+    prs = [
+        _make_pr_dated(1, "fix: bad date1", True, "not-a-date"),
+        _make_pr_dated(2, "fix: bad date2", True, "also-bad"),
+    ]
+    clusters = detect_clusters(prs, window=14, threshold=2)
+    assert len(clusters) == 1  # both fall to epoch, so they're in the same window


### PR DESCRIPTION
## 문제

기존 `detect_clusters`는 PR 번호 범위(`window * 3`)로 클러스터를 판별했습니다.
PR #57~#68처럼 단기간에 배포 장애가 연속 터지는 상황을 감지하려면, **PR 번호 거리**가 아닌 **실제 시간 거리**를 기준으로 삼아야 합니다.

예: PR #100이 1년 전, PR #101이 어제 머지됐다면 → 번호 윈도우에서는 같은 클러스터. 시간 윈도우에서는 분리.

## 변경 사항

**`src/analyze.py`**

| 항목 | 기존 | 변경 |
|------|------|------|
| 기준 | PR 번호 간격 (`window * 3`) | `mergedAt` 날짜 차이 |
| `window` 기본값 | `8` (PR 수 단위) | `14` (일 단위) |
| 정렬 | 입력 순서 | `mergedAt` 오름차순 |
| 경계 처리 | PR 번호 선형 스캔 | 정렬 후 break (이후 전부 범위 밖) |
| 날짜 파싱 실패 | N/A | epoch(2000-01-01) fallback |

알고리즘: Greedy Sliding Window
1. fix PR만 `mergedAt` 오름차순 정렬
2. 첫 번째 미분류 fix PR을 anchor로 설정
3. anchor로부터 `window`일 이내의 미분류 fix PR 전부 수집
4. 수집 크기 ≥ threshold → 클러스터 생성, 해당 PR 모두 분류 완료 처리
5. anchor 다음으로 이동 → 반복

**`tests/test_analyze.py`** — 5개 신규 테스트

| 테스트 | 검증 내용 |
|--------|----------|
| `test_time_window_cluster_within_14_days` | 10일 간격 fix 2개 → 클러스터 감지 |
| `test_time_window_no_cluster_beyond_window` | 20일 간격 → 클러스터 없음 |
| `test_time_window_two_separate_clusters` | 두 독립 버스트 → 각각 클러스터 |
| `test_time_window_boundary_exact_14_days` | 경계값 14일 → 포함(inclusive) |
| `test_time_window_malformed_date_fallback` | 파싱 실패 날짜 → epoch 폴백으로 묶임 |

## 하위 호환
- 기존 테스트 3개는 `merged_at="2026-01-01T00:00:00Z"` (동일 날짜) → 어떤 window 값에서도 통과
- `window=8` 명시적 전달 시 8일 윈도우로 동작 (의미 변경: PR 수 → 일)
- `detect_clusters` 콜 사이트 2곳 모두 기본값 사용 → 14일 윈도우 적용

## 테스트
- [x] `pytest tests/test_analyze.py` → 36 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)