### PR TITLE
feat(hook): PostToolUse real-time diff scoring via BM25

### DIFF
--- a/src/rag_hook.py
+++ b/src/rag_hook.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+PostToolUse 훅 — 방금 작성한 코드가 과거 회귀 패턴과 유사하면 즉시 경고.
+
+Claude Code PostToolUse 이벤트로 stdin에서 JSON을 받아 처리한다:
+  {"tool_name": "Edit", "tool_input": {"file_path": "...", "old_string": "...", "new_string": "..."}}
+
+BM25 pickle 캐시(ingest.py 실행 시 자동 생성)를 사용해 ChromaDB 없이도
+수십 ms 내로 과거 diff-pattern과의 유사도를 계산한다.
+
+설치:
+  .claude/settings.json 의 PostToolUse 훅에 이 스크립트를 등록한다.
+"""
+
+import json
+import pickle
+import re
+import sys
+from pathlib import Path
+
+DATA_DIR = Path(__file__).parent.parent / "data"
+BM25_CACHE_PATH = DATA_DIR / ".bm25_cache.pkl"
+
+# BM25 절대 점수 기준값: 이 이상일 때만 경고
+# 코드 전용 토크나이저 기준으로 기술 토큰 3~5개 이상 겹칠 때 대략 1.5 이상
+_SCORE_THRESHOLD = 1.5
+# 변경 내용이 너무 짧으면 노이즈가 많아 스킵
+_MIN_DIFF_LEN = 30
+
+
+def _tokenize(text: str) -> list[str]:
+    """tokenizer.py와 동일한 로직 — 의존성 없이 인라인으로 유지."""
+    parts = re.split(r'[\s\-_./:\\@\[\]{}()\'"=<>|&^%#!?;,~`]+', text)
+    result = []
+    for part in parts:
+        if not part:
+            continue
+        camel = re.sub(r'([a-z])([A-Z])', r'\1 \2', part)
+        for token in camel.split():
+            t = token.lower()
+            if t:
+                result.append(t)
+    return result
+
+
+def _extract_change(tool_name: str, tool_input: dict) -> str:
+    """Edit/Write tool_input에서 변경된 내용(새 코드)을 추출한다."""
+    if tool_name == "Edit":
+        # new_string이 실제로 추가된 내용
+        return tool_input.get("new_string", "")
+    if tool_name == "Write":
+        return tool_input.get("content", "")[:800]
+    return ""
+
+
+def main() -> None:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+
+    change = _extract_change(tool_name, tool_input)
+    if len(change.strip()) < _MIN_DIFF_LEN:
+        sys.exit(0)
+
+    if not BM25_CACHE_PATH.exists():
+        sys.exit(0)
+
+    try:
+        cache = pickle.loads(BM25_CACHE_PATH.read_bytes())
+        bm25 = cache["bm25"]
+        ids: list[str] = cache["ids"]
+        docs: list[str] = cache["docs"]
+    except Exception:
+        sys.exit(0)
+
+    tokens = _tokenize(change)
+    if not tokens:
+        sys.exit(0)
+
+    scores = bm25.get_scores(tokens)
+
+    # diff_pattern 타입만 대상으로 — 통계 청크는 오탐이 많음
+    diff_indices = [i for i, id_ in enumerate(ids) if id_.startswith("diff_")]
+    if not diff_indices:
+        sys.exit(0)
+
+    best_idx = max(diff_indices, key=lambda i: scores[i])
+    best_score = scores[best_idx]
+
+    if best_score < _SCORE_THRESHOLD:
+        sys.exit(0)
+
+    best_doc = docs[best_idx]
+    # 헤더 첫 줄: "[PR #N] 제목"
+    header = best_doc.split("\n")[0].strip()
+    file_path = tool_input.get("file_path", "")
+    filename = Path(file_path).name if file_path else "?"
+
+    print(f"⚠️  [{filename}] 방금 작성한 코드가 과거 회귀 패턴과 유사합니다 (BM25 {best_score:.1f})")
+    print(f"   패턴 참고: {header}")
+    print(f"   상세 분석: mcp diff_risk_score 툴로 확인하세요.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rag_hook.py
+++ b/tests/test_rag_hook.py
@@ -1,0 +1,182 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import json
+import pickle
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import rag_hook
+
+
+# ── _tokenize ────────────────────────────────────────────────────────────────
+
+def test_tokenize_splits_on_symbols():
+    tokens = rag_hook._tokenize("linux-musl-openssl-3.0.x")
+    assert "linux" in tokens
+    assert "musl" in tokens
+    assert "openssl" in tokens
+
+
+def test_tokenize_camelcase():
+    tokens = rag_hook._tokenize("BinaryTargets")
+    assert "binary" in tokens
+    assert "targets" in tokens
+
+
+def test_tokenize_empty():
+    assert rag_hook._tokenize("") == []
+
+
+# ── _extract_change ───────────────────────────────────────────────────────────
+
+def test_extract_change_edit():
+    result = rag_hook._extract_change(
+        "Edit",
+        {"file_path": "a.ts", "old_string": "old", "new_string": "new content here"},
+    )
+    assert result == "new content here"
+
+
+def test_extract_change_write():
+    result = rag_hook._extract_change(
+        "Write",
+        {"file_path": "a.ts", "content": "x" * 1000},
+    )
+    assert len(result) == 800  # truncated to 800
+
+
+def test_extract_change_unknown_tool():
+    result = rag_hook._extract_change("Bash", {"command": "ls"})
+    assert result == ""
+
+
+# ── main() integration ────────────────────────────────────────────────────────
+
+def _make_bm25_cache(docs: list[str], ids: list[str], tmp_path: Path) -> Path:
+    """실제 BM25Okapi 캐시를 임시 파일에 만들어 반환한다."""
+    from rank_bm25 import BM25Okapi
+    tokenized = [rag_hook._tokenize(d) for d in docs]
+    bm25 = BM25Okapi(tokenized)
+    cache = {"bm25": bm25, "ids": ids, "docs": docs}
+    cache_path = tmp_path / ".bm25_cache.pkl"
+    cache_path.write_bytes(pickle.dumps(cache))
+    return cache_path
+
+
+def test_main_warns_on_high_score(tmp_path, capsys, monkeypatch):
+    """BM25 점수가 임계값 이상이면 stdout에 경고를 출력한다."""
+    # BM25 IDF = log((N - df + 0.5) / (df + 0.5))
+    # df=1, N=2 → log(1) = 0 이므로 최소 3개 문서 필요
+    docs = [
+        "[PR #42] fix: prisma binaryTargets linux-musl-openssl missing\n[Domain: ci/cd]\n---\n- linux-musl-openssl-3.0.x binaryTargets",
+        "[PR #99] feat: add button component\n[Domain: ui]\n---\n+ <button>click</button>",
+        "[PR #55] chore: bump eslint version\n[Domain: maintenance]\n---\n eslint 9.0.0",
+    ]
+    ids = ["diff_repo_42", "diff_repo_99", "diff_repo_55"]
+    cache_path = _make_bm25_cache(docs, ids, tmp_path)
+
+    monkeypatch.setattr(rag_hook, "BM25_CACHE_PATH", cache_path)
+    monkeypatch.setattr(rag_hook, "_SCORE_THRESHOLD", 0.1)  # 낮게 설정
+
+    payload = json.dumps({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "prisma/schema.prisma",
+            "old_string": "old",
+            "new_string": "binaryTargets linux musl openssl fix missing",
+        },
+    })
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+
+    try:
+        rag_hook.main()
+    except SystemExit:
+        pass
+
+    out = capsys.readouterr().out
+    assert "⚠️" in out
+    assert "schema.prisma" in out
+
+
+def test_main_silent_on_low_score(tmp_path, capsys, monkeypatch):
+    """점수가 임계값 미만이면 아무 출력도 없다."""
+    docs = ["[PR #1] fix: unrelated thing\n---\nsome random content"]
+    ids = ["diff_repo_1"]
+    cache_path = _make_bm25_cache(docs, ids, tmp_path)
+
+    monkeypatch.setattr(rag_hook, "BM25_CACHE_PATH", cache_path)
+    monkeypatch.setattr(rag_hook, "_SCORE_THRESHOLD", 999.0)  # 절대 안 넘음
+
+    payload = json.dumps({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "src/foo.ts",
+            "old_string": "a",
+            "new_string": "completely different keywords xyz",
+        },
+    })
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+
+    try:
+        rag_hook.main()
+    except SystemExit:
+        pass
+
+    assert capsys.readouterr().out == ""
+
+
+def test_main_skips_non_diff_pattern_ids(tmp_path, capsys, monkeypatch):
+    """diff_ 접두사가 없는 청크는 경고 대상에서 제외된다."""
+    docs = ["lang_typescript 통계 요약: fix율 20%"]
+    ids = ["lang_typescript_summary"]  # diff_ 아님
+    cache_path = _make_bm25_cache(docs, ids, tmp_path)
+
+    monkeypatch.setattr(rag_hook, "BM25_CACHE_PATH", cache_path)
+    monkeypatch.setattr(rag_hook, "_SCORE_THRESHOLD", 0.001)
+
+    payload = json.dumps({
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "src/foo.ts",
+            "old_string": "a",
+            "new_string": "typescript fix율 통계 요약 lang",
+        },
+    })
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+
+    try:
+        rag_hook.main()
+    except SystemExit:
+        pass
+
+    assert capsys.readouterr().out == ""
+
+
+def test_main_skips_short_change(tmp_path, capsys, monkeypatch):
+    """변경 내용이 너무 짧으면 스킵한다."""
+    monkeypatch.setattr(rag_hook, "BM25_CACHE_PATH", tmp_path / "nonexistent.pkl")
+
+    payload = json.dumps({
+        "tool_name": "Edit",
+        "tool_input": {"file_path": "f.ts", "old_string": "x", "new_string": "y"},
+    })
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+
+    try:
+        rag_hook.main()
+    except SystemExit:
+        pass
+
+    assert capsys.readouterr().out == ""
+
+
+def test_main_handles_invalid_json(capsys, monkeypatch):
+    """stdin이 유효하지 않은 JSON이면 조용히 종료한다."""
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO("not json"))
+    try:
+        rag_hook.main()
+    except SystemExit:
+        pass
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

- `src/rag_hook.py` 추가: Claude Code PostToolUse 훅용 실시간 diff 스코어링
- BM25 pickle 캐시(`.bm25_cache.pkl`)만 사용 — ChromaDB 없이 수십 ms 이내 응답
- `diff_` 접두 청크만 대상으로 하여 통계 청크 오탐 제거
- `tests/test_rag_hook.py` 11개 테스트 추가 (전체 47개 통과)

## How it works

```
Edit/Write 완료
  → PostToolUse 이벤트 (stdin JSON)
  → rag_hook.py: new_string 추출 → BM25 토크나이징 → 과거 diff 패턴 유사도 계산
  → 임계값(1.5) 초과 시 stdout에 경고 출력 (Claude Code 화면에 표시)
```

## Score threshold

- `_SCORE_THRESHOLD = 1.5` — 기술 토큰 3~5개 이상 겹칠 때 발동 (노이즈 억제)
- `_MIN_DIFF_LEN = 30` — 너무 짧은 변경은 스킵

## Integration

gwangcheon-shop `.claude/settings.json`에 PostToolUse 훅으로 등록 예정 (별도 PR):

```json
"PostToolUse": [
  {"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "python3 /opt/gwangcheon-shop/worktrees/ai-dev-loop-analyzer/src/rag_hook.py"}]}
]
```

## Test plan

- [x] `pytest tests/test_rag_hook.py -v` — 11개 통과
- [x] BM25 IDF=0 엣지케이스 (N=2) 검증 → 3개 문서 픽스처로 해결
- [x] `diff_` 접두 필터링 동작 확인
- [x] 짧은 변경 스킵 확인
- [x] 유효하지 않은 JSON 조용히 종료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)