### PR TITLE
feat(multi-repo): per-repo data isolation with shared BM25 corpus

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -47,7 +47,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh label create "daily-report" --color "e4e669" --description "Daily auto-analysis report" 2>/dev/null || true
-          mkdir -p data
+          # 레포별 데이터 디렉토리 (멀티 레포 지원 — slug: owner_repo)
+          REPO_SLUG=$(echo "$TARGET_REPO" | tr '/' '_')
+          mkdir -p "data/repos/${REPO_SLUG}"
           touch data/rules-history.json
 
       - name: Checkout target repo
@@ -92,6 +94,58 @@ jobs:
           echo "cluster_count=$CLUSTER_COUNT" >> $GITHUB_OUTPUT
           echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
           echo "is_pr_trigger=$IS_PR_TRIGGER" >> $GITHUB_OUTPUT
+
+      # ── Step 1.5: analysis-cache 레포별 경로에 저장 ──────────────────────────
+      - name: Save analysis cache to per-repo directory
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, sys
+          sys.path.insert(0, 'src')
+          from repo_store import cache_path
+
+          target_repo = os.environ.get('TARGET_REPO', '')
+          if not target_repo:
+              sys.exit(0)
+
+          d = json.load(open('/tmp/report.json'))
+          summary = d.get('summary', {})
+          clusters = d.get('clusters', [])
+          risky_files = d.get('risky_files', [])
+          domain_counts = d.get('domain_counts', [])
+          ai_weak = d.get('ai_weak_domains', [])
+
+          import analyze as ana
+          file_last_diff = {}
+          for pr in d.get('fix_prs_with_diff', []):
+              if pr.get('diff_snippet'):
+                  for f in pr.get('files', []):
+                      file_last_diff[f] = {'title': pr['title'], 'diff': pr['diff_snippet']}
+
+          cache = {
+              'generated_at': __import__('datetime').date.today().isoformat(),
+              'repo': target_repo,
+              'fix_rate': summary.get('fix_rate', 0),
+              'summary': summary,
+              'risky_files': [
+                  {
+                      'file': f['file'],
+                      'fix_count': f['count'],
+                      'domain': ana.classify_domain('', [f['file']]),
+                      'last_fix_title': file_last_diff.get(f['file'], {}).get('title', ''),
+                      'last_diff_snippet': file_last_diff.get(f['file'], {}).get('diff', '')[:400],
+                  }
+                  for f in risky_files
+              ],
+              'domain_counts': domain_counts,
+              'ai_weak_domains': ai_weak,
+              'clusters': [{'start': c.get('start'), 'end': c.get('end'), 'domain': c.get('domain')} for c in clusters],
+          }
+          p = cache_path(target_repo)
+          p.write_text(json.dumps(cache, ensure_ascii=False, indent=2))
+          print(f'✅ analysis-cache 저장: {p}')
+          PYEOF
+        env:
+          TARGET_REPO: ${{ env.TARGET_REPO }}
 
       # ── Step 2: issue report ───────────────────────────────────────────────
       - name: Post daily report issue
@@ -438,11 +492,16 @@ jobs:
           PYEOF
 
       - name: 히스토리 파일 커밋
+        env:
+          TARGET_REPO: ${{ env.TARGET_REPO }}
         run: |
           git config user.name "ai-dev-loop-analyzer[bot]"
           git config user.email "ai-dev-loop-analyzer@users.noreply.github.com"
-          git add data/rules-history.json data/diff-patterns.json data/feedback-stats.json data/warning-log.jsonl || true
-          git diff --staged --quiet || git commit -m "data: daily snapshot ${{ steps.analyze.outputs.date }}"
+          REPO_SLUG=$(echo "$TARGET_REPO" | tr '/' '_')
+          # 공유 데이터 + 레포별 데이터 모두 커밋
+          git add data/rules-history.json data/diff-patterns.json || true
+          git add "data/repos/${REPO_SLUG}/" || true
+          git diff --staged --quiet || git commit -m "data: daily snapshot ${{ steps.analyze.outputs.date }} [${TARGET_REPO}]"
           git push
 
       # ── Step 4: patch CLAUDE.md ────────────────────────────────────────────

--- a/src/cli.py
+++ b/src/cli.py
@@ -11,37 +11,26 @@ ai-dev-loop-analyzer CLI 래퍼 — Claude Code PreToolUse 훅용
 
 동작:
   1. stdin JSON에서 tool_input.file_path 또는 tool_input.path를 추출
-  2. analysis-cache.json을 읽어 회귀 위험 파일 여부를 확인
-  3. 위험 있으면 stdout에 경고 출력 (Claude가 경고로 읽음)
-  4. 위험 없으면 조용히 종료 (exit 0, 출력 없음)
+  2. 현재 git remote에서 레포를 자동 감지 (AI_DEV_LOOP_REPO 환경변수로 override 가능)
+  3. 레포별 analysis-cache.json을 읽어 회귀 위험 파일 여부를 확인
+  4. 위험 있으면 stdout에 경고 출력 (Claude가 경고로 읽음)
+  5. 위험 없으면 조용히 종료 (exit 0, 출력 없음)
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
-# 경로 설정
 SRC_DIR = Path(__file__).parent
-ROOT = SRC_DIR.parent
-CACHE_FILE = ROOT / "data" / "analysis-cache.json"
-
 sys.path.insert(0, str(SRC_DIR))
 
-
-def load_cache() -> dict:
-    """분석 캐시 로드. 캐시 없으면 빈 dict 반환."""
-    if CACHE_FILE.exists():
-        try:
-            return json.loads(CACHE_FILE.read_text())
-        except Exception:
-            return {}
-    return {}
+from repo_store import detect_current_repo, load_cache
 
 
 def get_file_path_from_stdin() -> str | None:
     """stdin JSON에서 파일 경로 추출. 실패 시 None 반환."""
     if sys.stdin.isatty():
-        # 대화형 모드: stdin 없음
         return None
     try:
         raw = sys.stdin.read().strip()
@@ -49,26 +38,24 @@ def get_file_path_from_stdin() -> str | None:
             return None
         data = json.loads(raw)
         tool_input = data.get("tool_input", {})
-        # Edit/Write 모두 file_path 필드를 사용하지만 혹시 path도 체크
         return tool_input.get("file_path") or tool_input.get("path")
     except (json.JSONDecodeError, AttributeError):
         return None
 
 
-def check_risk(file_path: str) -> str | None:
+def check_risk(file_path: str, repo: str | None) -> str | None:
     """
-    캐시에서 해당 파일의 위험도를 확인.
+    레포별 캐시에서 해당 파일의 위험도를 확인.
     위험하면 경고 문자열 반환, 안전하면 None 반환.
     """
-    cache = load_cache()
+    cache = load_cache(repo)
     if not cache:
-        return None  # 캐시 없으면 조용히 통과
+        return None
 
     risky: dict[str, dict] = {
         item["file"]: item for item in cache.get("risky_files", [])
     }
 
-    # 정확히 일치하거나 접미사/접두사로 부분 매칭
     match = risky.get(file_path) or next(
         (v for k, v in risky.items() if file_path.endswith(k) or k.endswith(file_path)),
         None,
@@ -81,8 +68,9 @@ def check_risk(file_path: str) -> str | None:
     count = match.get("fix_count", 0)
     last_title = match.get("last_fix_title", "")
     file_name = Path(file_path).name
+    repo_label = f" [{repo}]" if repo else ""
 
-    lines = [f"[ai-dev-loop] {file_name} — {domain} 도메인에서 {count}회 수정 이력"]
+    lines = [f"[ai-dev-loop]{repo_label} {file_name} — {domain} 도메인에서 {count}회 수정 이력"]
     if last_title:
         lines.append(f"    마지막 fix: {last_title}")
 
@@ -97,16 +85,15 @@ def main():
         file_path = get_file_path_from_stdin()
 
     if not file_path:
-        # 파일 경로를 특정할 수 없으면 조용히 통과
         sys.exit(0)
 
-    warning = check_risk(file_path)
+    # 레포 감지: 환경변수 → git remote 자동 감지 → None(fallback)
+    repo = os.environ.get("AI_DEV_LOOP_REPO") or detect_current_repo()
+
+    warning = check_risk(file_path, repo)
     if warning:
         print(warning)
-        # exit 0: Claude Code는 exit code가 아닌 stdout 내용으로 경고를 판단
-        sys.exit(0)
-    else:
-        sys.exit(0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/src/feedback.py
+++ b/src/feedback.py
@@ -3,9 +3,9 @@
 경고 피드백 루프 — rag_hook.py 경고가 실제 회귀를 예측했는지 측정.
 
 흐름:
-  1. rag_hook.py가 경고 발생 시 warning-log.jsonl에 기록
+  1. rag_hook.py가 경고 발생 시 레포별 warning-log.jsonl에 기록
   2. evolve-rules.yml 실행 시 evaluate()로 warning-log와 fix PR 교차 검증
-  3. 결과를 feedback-stats.json에 저장 (MCP / 리포트에 노출)
+  3. 결과를 레포별 feedback-stats.json에 저장 (MCP / 리포트에 노출)
 
 피드백 판정 기준:
   - TRUE_POSITIVE:  경고 후 14일 이내 같은 파일/도메인에 fix PR 등장
@@ -14,15 +14,26 @@
 """
 
 import json
+import os
 import re
+import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-DATA_DIR = Path(__file__).parent.parent / "data"
-WARNING_LOG = DATA_DIR / "warning-log.jsonl"
-FEEDBACK_STATS = DATA_DIR / "feedback-stats.json"
+sys.path.insert(0, str(Path(__file__).parent))
+from repo_store import (
+    detect_current_repo,
+    warning_log_path,
+    feedback_stats_path,
+    repo_data_dir,
+)
 
 _VERDICT_WINDOW_DAYS = 14
+
+
+def _resolve_repo(repo: str | None) -> str | None:
+    """repo 파라미터가 없으면 환경변수 → git remote 순으로 자동 감지."""
+    return repo or os.environ.get("AI_DEV_LOOP_REPO") or detect_current_repo()
 
 
 def record_warning(
@@ -30,8 +41,13 @@ def record_warning(
     bm25_score: float,
     matched_id: str,
     matched_header: str,
+    repo: str | None = None,
 ) -> None:
-    """경고 발생 시 즉시 호출 — warning-log.jsonl에 한 줄 append."""
+    """경고 발생 시 즉시 호출 — 레포별 warning-log.jsonl에 한 줄 append."""
+    resolved = _resolve_repo(repo)
+    if not resolved:
+        return  # 레포를 특정할 수 없으면 로깅 생략
+
     entry = {
         "ts": datetime.now(timezone.utc).isoformat(),
         "file": file_path,
@@ -40,16 +56,17 @@ def record_warning(
         "matched_header": matched_header,
         "verdict": "PENDING",
     }
-    DATA_DIR.mkdir(exist_ok=True)
-    with WARNING_LOG.open("a", encoding="utf-8") as f:
+    log_path = warning_log_path(resolved)
+    with log_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
-def _load_warnings() -> list[dict]:
-    if not WARNING_LOG.exists():
+def _load_warnings(repo: str) -> list[dict]:
+    log_path = warning_log_path(repo)
+    if not log_path.exists():
         return []
     warnings = []
-    for line in WARNING_LOG.read_text(encoding="utf-8").splitlines():
+    for line in log_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if line:
             try:
@@ -59,37 +76,39 @@ def _load_warnings() -> list[dict]:
     return warnings
 
 
-def _save_warnings(warnings: list[dict]) -> None:
-    DATA_DIR.mkdir(exist_ok=True)
-    with WARNING_LOG.open("w", encoding="utf-8") as f:
+def _save_warnings(repo: str, warnings: list[dict]) -> None:
+    log_path = warning_log_path(repo)
+    with log_path.open("w", encoding="utf-8") as f:
         for w in warnings:
             f.write(json.dumps(w, ensure_ascii=False) + "\n")
 
 
-def evaluate(fix_prs: list[dict]) -> dict:
+def evaluate(fix_prs: list[dict], repo: str | None = None) -> dict:
     """
-    warning-log와 fix PR 목록을 교차 검증해 verdict를 갱신하고
+    레포별 warning-log와 fix PR 목록을 교차 검증해 verdict를 갱신하고
     정확도 통계를 반환한다.
 
     fix_prs 항목 형식: {"files": [...], "domain": "...", "merged_at": "ISO8601", "title": "..."}
     """
-    warnings = _load_warnings()
+    resolved = _resolve_repo(repo)
+    if not resolved:
+        return {}
+
+    warnings = _load_warnings(resolved)
     now = datetime.now(timezone.utc)
     cutoff = timedelta(days=_VERDICT_WINDOW_DAYS)
 
     for w in warnings:
         if w.get("verdict") != "PENDING":
             continue
-
         try:
             warned_at = datetime.fromisoformat(w["ts"].replace("Z", "+00:00"))
         except Exception:
             continue
 
         elapsed = now - warned_at
-
-        # fix PR과 교차 검증: 경고 이후 머지된 fix PR이 같은 파일/도메인을 건드렸는가
         matched_fix = False
+
         for pr in fix_prs:
             try:
                 pr_merged = datetime.fromisoformat(pr["merged_at"].replace("Z", "+00:00"))
@@ -98,15 +117,12 @@ def evaluate(fix_prs: list[dict]) -> dict:
             if pr_merged < warned_at:
                 continue
 
-            # 파일 경로 일치: 경고 파일이 fix PR 변경 파일 중 하나인지
             warn_file = w.get("file", "")
             pr_files = pr.get("files", [])
             file_hit = any(
-                warn_file.endswith(f) or f.endswith(warn_file)
-                for f in pr_files
+                warn_file.endswith(f) or f.endswith(warn_file) for f in pr_files
             )
 
-            # 도메인 일치: matched_id가 도메인 접두사를 포함하는지 (휴리스틱)
             matched_id = w.get("matched_id", "")
             pr_domain = pr.get("domain", "")
             domain_hint = _extract_domain_from_id(matched_id)
@@ -120,27 +136,22 @@ def evaluate(fix_prs: list[dict]) -> dict:
             w["verdict"] = "TRUE_POSITIVE"
         elif elapsed > cutoff:
             w["verdict"] = "FALSE_POSITIVE"
-        # else: 아직 PENDING 유지
 
-    _save_warnings(warnings)
+    _save_warnings(resolved, warnings)
 
-    # 통계 집계
     total = len(warnings)
     tp = sum(1 for w in warnings if w["verdict"] == "TRUE_POSITIVE")
     fp = sum(1 for w in warnings if w["verdict"] == "FALSE_POSITIVE")
     pending = sum(1 for w in warnings if w["verdict"] == "PENDING")
     judged = tp + fp
-
     precision = round(tp / judged * 100, 1) if judged else None
 
-    # 도메인별 분류
     domain_stats: dict[str, dict] = {}
     for w in warnings:
         d = _extract_domain_from_id(w.get("matched_id", "")) or "unknown"
         s = domain_stats.setdefault(d, {"tp": 0, "fp": 0, "pending": 0})
         s[w["verdict"].lower() if w["verdict"] != "PENDING" else "pending"] += 1
 
-    # 오탐이 많은 도메인 (threshold 조정 후보)
     noisy_domains = [
         d for d, s in domain_stats.items()
         if s["fp"] > s["tp"] and s["fp"] >= 2
@@ -148,6 +159,7 @@ def evaluate(fix_prs: list[dict]) -> dict:
 
     stats = {
         "updated_at": now.isoformat(),
+        "repo": resolved,
         "total_warnings": total,
         "true_positives": tp,
         "false_positives": fp,
@@ -158,12 +170,13 @@ def evaluate(fix_prs: list[dict]) -> dict:
         "threshold_suggestion": _suggest_threshold(warnings),
     }
 
-    FEEDBACK_STATS.write_text(json.dumps(stats, ensure_ascii=False, indent=2))
+    feedback_stats_path(resolved).write_text(
+        json.dumps(stats, ensure_ascii=False, indent=2)
+    )
     return stats
 
 
 def _extract_domain_from_id(matched_id: str) -> str:
-    """diff_repo_N 형태의 ID에서 도메인 힌트를 추출한다 (휴리스틱)."""
     domain_keywords = [
         "auth", "payment", "database", "ci", "cd", "security",
         "api", "ui", "config", "test", "maintenance", "docs",
@@ -176,10 +189,6 @@ def _extract_domain_from_id(matched_id: str) -> str:
 
 
 def _suggest_threshold(warnings: list[dict]) -> dict | None:
-    """
-    FALSE_POSITIVE가 많은 경우 BM25 임계값을 높이도록 제안.
-    점수 분포를 분석해 TP와 FP의 경계 점수를 추정.
-    """
     tp_scores = [w["score"] for w in warnings if w["verdict"] == "TRUE_POSITIVE"]
     fp_scores = [w["score"] for w in warnings if w["verdict"] == "FALSE_POSITIVE"]
 
@@ -190,10 +199,11 @@ def _suggest_threshold(warnings: list[dict]) -> dict | None:
     fp_max = max(fp_scores)
 
     if fp_max < tp_min:
-        # TP와 FP가 완전히 분리된 이상적 케이스 → 현재 임계값 유지
-        return {"action": "keep", "reason": f"TP/FP 점수가 완전 분리 (FP max {fp_max:.2f} < TP min {tp_min:.2f})"}
+        return {
+            "action": "keep",
+            "reason": f"TP/FP 점수 완전 분리 (FP max {fp_max:.2f} < TP min {tp_min:.2f})",
+        }
 
-    # 겹치는 경우 → TP 최솟값을 새 임계값으로 제안
     suggested = round(tp_min, 1)
     return {
         "action": "raise",
@@ -203,17 +213,47 @@ def _suggest_threshold(warnings: list[dict]) -> dict | None:
     }
 
 
-def feedback_report() -> str:
+def feedback_report(repo: str | None = None) -> str:
     """MCP / CLI에서 출력할 피드백 요약 문자열."""
-    if not FEEDBACK_STATS.exists():
-        return "피드백 데이터 없음 — evolve-rules 워크플로우 실행 후 생성됩니다."
+    from repo_store import list_registered_repos, feedback_stats_path as fsp
 
-    s = json.loads(FEEDBACK_STATS.read_text())
+    resolved = _resolve_repo(repo)
+
+    # 단일 레포 지정
+    if resolved:
+        p = fsp(resolved)
+        if not p.exists():
+            return f"[{resolved}] 피드백 데이터 없음 — evolve-rules 실행 후 생성됩니다."
+        return _format_stats(json.loads(p.read_text()))
+
+    # 전체 레포 요약
+    repos = list_registered_repos()
+    if not repos:
+        return "등록된 레포 없음 — analyze_pr_history를 먼저 실행하세요."
+
+    lines = ["## 전체 레포 경고 정밀도 요약\n"]
+    for r in repos:
+        p = fsp(r)
+        if p.exists():
+            s = json.loads(p.read_text())
+            prec = s.get("precision_pct")
+            prec_str = f"{prec}%" if prec is not None else "측정 중"
+            lines.append(
+                f"- **{r}**: TP {s['true_positives']} / FP {s['false_positives']} "
+                f"/ 대기 {s['pending']} | 정밀도 {prec_str}"
+            )
+        else:
+            lines.append(f"- **{r}**: 피드백 데이터 없음")
+    return "\n".join(lines)
+
+
+def _format_stats(s: dict) -> str:
     precision = s.get("precision_pct")
     prec_str = f"{precision}%" if precision is not None else "측정 중"
+    repo = s.get("repo", "?")
 
     lines = [
-        f"### 🎯 경고 피드백 통계 (갱신: {s.get('updated_at', '?')[:10]})",
+        f"### 🎯 [{repo}] 경고 피드백 통계 (갱신: {s.get('updated_at', '?')[:10]})",
         f"- 전체 경고: {s['total_warnings']}건",
         f"- 진짜 회귀 예측 (TP): {s['true_positives']}건",
         f"- 오탐 (FP): {s['false_positives']}건",

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -30,23 +30,17 @@ from mcp.types import TextContent, Tool
 # ── 경로 설정 ─────────────────────────────────────────────────────────────────
 ROOT = Path(__file__).parent.parent
 DATA_DIR = ROOT / "data"
-CACHE_FILE = DATA_DIR / "analysis-cache.json"
 HISTORY_FILE = DATA_DIR / "rules-history.json"
 SRC_DIR = Path(__file__).parent
 
 sys.path.insert(0, str(SRC_DIR))
 
 import analyze as _ana  # noqa: E402
+from repo_store import load_cache, list_registered_repos, cache_path  # noqa: E402
 
 _profile_path = os.environ.get("AI_DEV_LOOP_PROFILE")
 if _profile_path and Path(_profile_path).exists():
     _ana.load_profile(_profile_path)
-
-# ── 캐시 로드 ─────────────────────────────────────────────────────────────────
-def load_cache() -> dict:
-    if CACHE_FILE.exists():
-        return json.loads(CACHE_FILE.read_text())
-    return {}
 
 def load_history() -> dict:
     if HISTORY_FILE.exists():
@@ -55,13 +49,12 @@ def load_history() -> dict:
 
 
 # ── 도구 구현 ─────────────────────────────────────────────────────────────────
-def _check_risk_zones(file_paths: list[str]) -> str:
+def _check_risk_zones(file_paths: list[str], repo: str | None = None) -> str:
     """
     편집하려는 파일들이 과거 회귀 핫존인지 확인.
-    캐시된 분석 데이터를 사용하므로 빠르게 응답.
-    diff 스니펫이 있으면 "마지막으로 이 파일이 고쳐졌을 때 변경 내용"도 함께 표시.
+    repo 지정 시 해당 레포 캐시만 조회. 미지정 시 등록된 첫 번째 레포 사용.
     """
-    cache = load_cache()
+    cache = load_cache(repo)
     if not cache:
         return (
             "⚠️ 캐시 없음 — `analyze_pr_history`를 먼저 실행하거나 "
@@ -249,7 +242,8 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
         "ai_weak_domains": ai_stats["ai"]["weak_domains"],
         "clusters": [{"start": c.start, "end": c.end, "domain": c.domain} for c in clusters],
     }
-    CACHE_FILE.write_text(json.dumps(cache, ensure_ascii=False, indent=2))
+    # 레포별 경로에 저장 (멀티 레포 지원)
+    cache_path(repo).write_text(json.dumps(cache, ensure_ascii=False, indent=2))
 
     # 응답 구성
     lines = [
@@ -443,7 +437,7 @@ TOOLS = [
             "Check whether the files you are about to edit are known regression hotspots. "
             "Call this before modifying a file to receive warnings such as "
             "'this file has regressed 4 times in the payment domain'. "
-            "Turns retrospective analysis into prospective warnings."
+            "Supports multiple repos — specify repo to query a specific project's history."
         ),
         inputSchema={
             "type": "object",
@@ -452,7 +446,12 @@ TOOLS = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "확인할 파일 경로 목록 (예: ['src/lib/auth.ts', 'next.config.ts'])",
-                }
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "조회할 레포 (예: 'owner/repo'). 미지정 시 첫 번째 등록 레포 사용.",
+                    "default": "",
+                },
             },
             "required": ["file_paths"],
         },
@@ -551,7 +550,25 @@ TOOLS = [
         description=(
             "PostToolUse 훅 경고의 정밀도(Precision)를 조회합니다. "
             "경고가 실제 회귀로 이어졌는지(TP) vs 오탐(FP)인지 통계와 "
-            "BM25 임계값 조정 제안을 반환합니다."
+            "BM25 임계값 조정 제안을 반환합니다. "
+            "repo 미지정 시 등록된 전체 레포의 요약을 반환합니다."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "조회할 레포 (예: 'owner/repo'). 미지정 시 전체 레포 요약.",
+                    "default": "",
+                },
+            },
+        },
+    ),
+    Tool(
+        name="list_repos",
+        description=(
+            "분석 캐시가 존재하는 등록 레포 목록을 반환합니다. "
+            "멀티 레포 환경에서 어떤 레포가 추적되고 있는지 확인할 때 사용합니다."
         ),
         inputSchema={
             "type": "object",
@@ -570,7 +587,10 @@ async def list_tools():
 async def call_tool(name: str, arguments: dict):
     try:
         if name == "check_risk_zones":
-            text = _check_risk_zones(arguments.get("file_paths", []))
+            text = _check_risk_zones(
+                arguments.get("file_paths", []),
+                arguments.get("repo") or None,
+            )
         elif name == "suggest_review_checklist":
             text = _suggest_review_checklist(
                 arguments["pr_title"],
@@ -590,7 +610,21 @@ async def call_tool(name: str, arguments: dict):
             text = _get_active_rules(arguments.get("domain", ""))
         elif name == "get_warning_feedback":
             from feedback import feedback_report
-            text = feedback_report()
+            text = feedback_report(arguments.get("repo") or None)
+        elif name == "list_repos":
+            repos = list_registered_repos()
+            if not repos:
+                text = "등록된 레포 없음 — `analyze_pr_history`를 먼저 실행하세요."
+            else:
+                lines = [f"## 등록된 레포 ({len(repos)}개)\n"]
+                for r in repos:
+                    p = cache_path(r)
+                    import json as _json
+                    cache = _json.loads(p.read_text()) if p.exists() else {}
+                    fix_rate = cache.get("fix_rate", "?")
+                    analyzed_at = cache.get("generated_at", "?")
+                    lines.append(f"- **{r}** | fix율 {fix_rate}% | 분석: {analyzed_at}")
+                text = "\n".join(lines)
         else:
             text = f"알 수 없는 도구: {name}"
     except Exception as e:

--- a/src/repo_store.py
+++ b/src/repo_store.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+레포별 데이터 경로 관리 — 멀티 레포 지원 핵심 모듈.
+
+공유 데이터 (전 레포 공통):
+  data/diff-patterns.json      — BM25/벡터 학습용 diff 패턴
+  data/language-patterns.json  — 언어별 크로스 레포 통계
+  data/.bm25_cache.pkl         — BM25 인덱스 (전 레포 합산)
+
+레포별 데이터 (레포마다 독립):
+  data/repos/{slug}/analysis-cache.json  — 회귀 파일·클러스터·도메인 분석
+  data/repos/{slug}/warning-log.jsonl    — PostToolUse 경고 로그
+  data/repos/{slug}/feedback-stats.json  — 경고 정밀도 통계
+
+하위 호환:
+  data/analysis-cache.json 이 있으면 fallback으로 사용 (v0.x 마이그레이션).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+DATA_DIR = Path(__file__).parent.parent / "data"
+REPOS_DIR = DATA_DIR / "repos"
+
+# 하위 호환: 구버전 단일 레포 캐시 경로
+_LEGACY_CACHE = DATA_DIR / "analysis-cache.json"
+
+
+def repo_slug(repo: str) -> str:
+    """'owner/repo' → 'owner_repo' (디렉토리명으로 사용 가능한 형태)."""
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", repo)
+
+
+def repo_data_dir(repo: str) -> Path:
+    """레포별 데이터 디렉토리. 없으면 자동 생성."""
+    path = REPOS_DIR / repo_slug(repo)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def cache_path(repo: str) -> Path:
+    return repo_data_dir(repo) / "analysis-cache.json"
+
+
+def warning_log_path(repo: str) -> Path:
+    return repo_data_dir(repo) / "warning-log.jsonl"
+
+
+def feedback_stats_path(repo: str) -> Path:
+    return repo_data_dir(repo) / "feedback-stats.json"
+
+
+def load_cache(repo: str | None = None) -> dict:
+    """
+    레포 지정 시 레포별 캐시 로드.
+    미지정 시 등록된 첫 번째 레포 또는 legacy 캐시 fallback.
+    """
+    import json
+
+    if repo:
+        p = cache_path(repo)
+        if p.exists():
+            return json.loads(p.read_text())
+        # 레포가 지정됐지만 캐시가 없으면 빈 dict (analyze_pr_history 먼저 실행 필요)
+        return {}
+
+    # repo 미지정: 등록된 레포 중 첫 번째 사용
+    registered = list_registered_repos()
+    for r in registered:
+        p = cache_path(r)
+        if p.exists():
+            return json.loads(p.read_text())
+
+    # legacy fallback (v0.x 호환)
+    if _LEGACY_CACHE.exists():
+        import json
+        return json.loads(_LEGACY_CACHE.read_text())
+
+    return {}
+
+
+def list_registered_repos() -> list[str]:
+    """data/repos/ 하위 디렉토리 존재 여부로 등록 레포 목록 반환."""
+    if not REPOS_DIR.exists():
+        return []
+    return [
+        d.name.replace("_", "/", 1)  # slug → owner/repo (첫 번째 _ 만 치환)
+        for d in sorted(REPOS_DIR.iterdir())
+        if d.is_dir() and (d / "analysis-cache.json").exists()
+    ]
+
+
+def detect_current_repo() -> str | None:
+    """
+    현재 디렉토리의 git remote origin에서 레포 이름을 자동 감지.
+    GitHub URL 형식: https://github.com/owner/repo.git
+                     git@github.com:owner/repo.git
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=3,
+        )
+        url = result.stdout.strip()
+        # SSH: git@github.com:owner/repo.git
+        m = re.search(r"github\.com[:/]([^/]+/[^/]+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    return None


### PR DESCRIPTION
## Summary

레포별 분석 상태를 격리하면서 BM25 학습 데이터는 공유하는 멀티 레포 아키텍처 구현.

## 데이터 구조 변경

```
data/
  repos/                                ← NEW: 레포별 격리 디렉토리
    rladmsgh34_gwangcheon-shop/
      analysis-cache.json               ← 회귀 파일·클러스터 (레포별)
      warning-log.jsonl                 ← PostToolUse 경고 로그 (레포별)
      feedback-stats.json               ← 경고 정밀도 통계 (레포별)
    owner_another-repo/
      analysis-cache.json
      ...
  diff-patterns.json                    ← 공유 (크로스 레포 BM25 품질 향상)
  language-patterns.json                ← 공유
  .bm25_cache.pkl                       ← 공유 (전 레포 합산)
```

## 변경된 파일

### `src/repo_store.py` (신규)
레포 슬러그 변환, 경로 해석, 레포 자동 감지 로직을 한 곳에서 관리.
- `repo_slug("owner/repo")` → `"owner_repo"`
- `cache_path(repo)` → `data/repos/{slug}/analysis-cache.json`
- `detect_current_repo()` — git remote origin에서 자동 감지
- `list_registered_repos()` — analysis-cache 존재하는 레포 목록
- `load_cache(repo=None)` — repo 미지정 시 fallback 체인 (등록 레포 → legacy)

### `src/cli.py`
- `AI_DEV_LOOP_REPO` 환경변수 → git remote 자동 감지 순으로 레포 결정
- 레포별 캐시 조회 → 경고에 `[owner/repo]` 레이블 추가

### `src/feedback.py`
- `record_warning(repo=)` — 레포별 warning-log에 분리 저장
- `evaluate(repo=)` — 레포별 교차 검증
- `feedback_report(repo=None)` — 미지정 시 전체 레포 요약

### `src/mcp_server.py`
- `check_risk_zones(file_paths, repo="")` — repo 파라미터 추가
- `get_warning_feedback(repo="")` — 레포별 또는 전체 요약
- `list_repos()` 신규 툴 — 등록된 레포 목록 조회

### `.github/workflows/evolve-rules.yml`
- Step 1.5 추가: analysis-cache를 `data/repos/{slug}/`에 저장
- 커밋 스텝: 레포별 디렉토리 전체 포함

## 사용 예시

```bash
# 두 번째 레포 추가 시 evolve-rules.yml을 TARGET_REPO만 바꿔 재실행
gh workflow run evolve-rules.yml \
  -f target_repo=owner/another-repo

# 이후 자동으로 data/repos/owner_another-repo/ 생성
```

```
# MCP에서 멀티 레포 조회
list_repos()
# → "rladmsgh34/gwangcheon-shop (fix율 14.5%, 분석: 2026-04-26)"
# → "owner/another-repo (fix율 8.2%, 분석: 2026-04-25)"

check_risk_zones(["src/lib/auth.ts"], repo="owner/another-repo")
```

## 하위 호환성

- `data/analysis-cache.json` (구버전) 존재 시 fallback으로 로드 — 마이그레이션 없이 업그레이드 가능

## Test plan

- [x] `repo_store.py` 경로 계산 검증
- [x] `feedback.py` 레포별 파일 분리 검증
- [x] `list_registered_repos()` analysis-cache 기준 동작 확인
- [x] `detect_current_repo()` git remote 파싱 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)