### PR TITLE
fix(multi-repo): bundle PR #27 review fixes (7 critical/high/medium issues)

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -96,56 +96,37 @@ jobs:
           echo "is_pr_trigger=$IS_PR_TRIGGER" >> $GITHUB_OUTPUT
 
       # ── Step 1.5: analysis-cache 레포별 경로에 저장 ──────────────────────────
+      # 캐시 빌드는 analyze.build_cache_dict()로 위임 (mcp_server와 동일 함수 사용 → 스키마 드리프트 차단).
+      # 도메인 분류 정확도를 위해 AI_DEV_LOOP_PROFILE을 명시적으로 전달.
       - name: Save analysis cache to per-repo directory
+        env:
+          TARGET_REPO: ${{ env.TARGET_REPO }}
+          AI_DEV_LOOP_PROFILE: target-repo/.claude/ai-dev-loop-profile.json
         run: |
           python3 - <<'PYEOF'
           import json, os, sys
+          from pathlib import Path
           sys.path.insert(0, 'src')
-          from repo_store import cache_path
 
           target_repo = os.environ.get('TARGET_REPO', '')
           if not target_repo:
+              print('TARGET_REPO 미지정 — 스킵')
               sys.exit(0)
 
-          d = json.load(open('/tmp/report.json'))
-          summary = d.get('summary', {})
-          clusters = d.get('clusters', [])
-          risky_files = d.get('risky_files', [])
-          domain_counts = d.get('domain_counts', [])
-          ai_weak = d.get('ai_weak_domains', [])
-
           import analyze as ana
-          file_last_diff = {}
-          for pr in d.get('fix_prs_with_diff', []):
-              if pr.get('diff_snippet'):
-                  for f in pr.get('files', []):
-                      file_last_diff[f] = {'title': pr['title'], 'diff': pr['diff_snippet']}
+          profile_path = os.environ.get('AI_DEV_LOOP_PROFILE')
+          if profile_path and Path(profile_path).exists():
+              ana.load_profile(profile_path)
+              print(f'프로파일 로드: {profile_path}')
 
-          cache = {
-              'generated_at': __import__('datetime').date.today().isoformat(),
-              'repo': target_repo,
-              'fix_rate': summary.get('fix_rate', 0),
-              'summary': summary,
-              'risky_files': [
-                  {
-                      'file': f['file'],
-                      'fix_count': f['count'],
-                      'domain': ana.classify_domain('', [f['file']]),
-                      'last_fix_title': file_last_diff.get(f['file'], {}).get('title', ''),
-                      'last_diff_snippet': file_last_diff.get(f['file'], {}).get('diff', '')[:400],
-                  }
-                  for f in risky_files
-              ],
-              'domain_counts': domain_counts,
-              'ai_weak_domains': ai_weak,
-              'clusters': [{'start': c.get('start'), 'end': c.get('end'), 'domain': c.get('domain')} for c in clusters],
-          }
+          report = json.load(open('/tmp/report.json'))
+          cache = ana.build_cache_dict(report, target_repo)
+
+          from repo_store import cache_path
           p = cache_path(target_repo)
           p.write_text(json.dumps(cache, ensure_ascii=False, indent=2))
           print(f'✅ analysis-cache 저장: {p}')
           PYEOF
-        env:
-          TARGET_REPO: ${{ env.TARGET_REPO }}
 
       # ── Step 2: issue report ───────────────────────────────────────────────
       - name: Post daily report issue
@@ -463,17 +444,27 @@ jobs:
           TARGET_REPO: ${{ env.TARGET_REPO }}
 
       # ── Step 3.6: 피드백 루프 — 경고 로그 vs fix PR 교차 검증 ─────────────
+      # rag_hook.py가 data/repos/{slug}/warning-log.jsonl에 기록한 경고를
+      # 같은 레포의 fix PR과 대조해 TP/FP 판정. 반드시 TARGET_REPO를 명시해야
+      # GH 러너 git remote(=ai-dev-loop-analyzer)를 잘못 감지하지 않음.
       - name: 경고 피드백 정밀도 평가
         continue-on-error: true
+        env:
+          TARGET_REPO: ${{ env.TARGET_REPO }}
         run: |
           python3 - <<'PYEOF'
-          import json, sys
-          from pathlib import Path
+          import json, os, sys
           sys.path.insert(0, 'src')
 
-          warning_log = Path("data/warning-log.jsonl")
-          if not warning_log.exists():
-              print("경고 로그 없음 — 스킵 (rag_hook 경고가 아직 발생하지 않은 상태)")
+          target_repo = os.environ.get('TARGET_REPO', '')
+          if not target_repo:
+              print('TARGET_REPO 미지정 — 스킵')
+              sys.exit(0)
+
+          from repo_store import warning_log_path
+          log_path = warning_log_path(target_repo, create=False)
+          if not log_path.exists():
+              print(f'경고 로그 없음 ({log_path}) — 스킵 (rag_hook 경고가 아직 발생하지 않은 상태)')
               sys.exit(0)
 
           d = json.load(open('/tmp/report.json'))
@@ -487,8 +478,8 @@ jobs:
               })
 
           from feedback import evaluate, feedback_report
-          stats = evaluate(fix_prs)
-          print(feedback_report())
+          stats = evaluate(fix_prs, repo=target_repo)
+          print(feedback_report(repo=target_repo))
           PYEOF
 
       - name: 히스토리 파일 커밋

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ __pycache__/
 !package.json
 !data/language-patterns.json
 !data/rules-history.json
+# 멀티 레포: 레포별 분석/피드백 데이터는 추적 (warning-log는 dev 머신 local-only)
+!data/repos/
+!data/repos/**/analysis-cache.json
+!data/repos/**/feedback-stats.json
+data/repos/**/warning-log.jsonl
 !profiles/**/*.json
 .DS_Store
 data/chroma/

--- a/scripts/migrate_to_multi_repo.py
+++ b/scripts/migrate_to_multi_repo.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+v0.x → v1.0 마이그레이션 — 단일 레포 캐시를 멀티 레포 구조로 이전.
+
+이전: data/analysis-cache.json (한 파일에 한 레포)
+이후: data/repos/{slug}/analysis-cache.json (레포별 디렉토리)
+
+`repo` 필드를 cache 안에서 읽어 정확한 슬러그 디렉토리에 이동한다.
+이미 마이그레이션 됐거나 legacy 파일이 없으면 no-op.
+
+실행:
+  python3 scripts/migrate_to_multi_repo.py [--dry-run]
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from repo_store import cache_path, _LEGACY_CACHE  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not _LEGACY_CACHE.exists():
+        print("legacy data/analysis-cache.json 없음 — 마이그레이션 불필요")
+        return
+
+    try:
+        data = json.loads(_LEGACY_CACHE.read_text())
+    except Exception as e:
+        print(f"legacy 파일 파싱 실패: {e}")
+        sys.exit(1)
+
+    repo = data.get("repo")
+    if not repo:
+        print("legacy 파일에 'repo' 필드 없음 — 수동 처리 필요")
+        sys.exit(1)
+
+    target = cache_path(repo, create=False)
+    if target.exists():
+        print(f"⚠️  대상 이미 존재: {target} — legacy 삭제만 진행 ({'dry-run' if args.dry_run else 'execute'})")
+        if not args.dry_run:
+            _LEGACY_CACHE.unlink()
+        return
+
+    print(f"이동: {_LEGACY_CACHE} → {target}")
+    if args.dry_run:
+        print("(dry-run — 실제 이동 안 함)")
+        return
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(_LEGACY_CACHE), str(target))
+    print(f"✅ 마이그레이션 완료 (repo: {repo})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -567,6 +567,61 @@ def _call_github_models(prompt: str, token: str, model: str) -> list[str]:
         return []
 
 
+# ── 캐시 빌더 — mcp_server / evolve-rules.yml 양쪽이 공유 ──────────────────
+def build_cache_dict(report: dict, repo: str) -> dict:
+    """
+    analyze.py JSON 출력(report dict)에서 analysis-cache.json 구조를 만든다.
+
+    호출처:
+      - mcp_server.py:_analyze_pr_history (in-process, prs → report → cache)
+      - evolve-rules.yml Step 1.5 (subprocess, /tmp/report.json → cache)
+
+    두 곳에서 같은 함수를 사용해야 캐시 스키마 드리프트가 발생하지 않는다.
+    """
+    summary = report.get("summary", {})
+    risky_files = report.get("risky_files", [])
+    domain_counts = report.get("domain_counts", [])
+    ai_vs_human = report.get("ai_vs_human", {})
+    clusters = report.get("clusters", [])
+
+    # 파일별 마지막 fix diff 인덱스
+    file_last_diff: dict[str, dict] = {}
+    for pr in report.get("fix_prs_with_diff", []):
+        diff = pr.get("diff_snippet", "")
+        if not diff:
+            continue
+        for f in pr.get("files", []):
+            file_last_diff[f] = {"title": pr.get("title", ""), "diff": diff}
+
+    return {
+        "generated_at": __import__("datetime").date.today().isoformat(),
+        "repo": repo,
+        "fix_rate": summary.get("fix_rate", 0),
+        "summary": summary,
+        "risky_files": [
+            {
+                "file": f["file"],
+                "fix_count": f["fix_count"],
+                "domain": classify_domain("", [f["file"]]),
+                "last_fix_title": file_last_diff.get(f["file"], {}).get("title", ""),
+                "last_diff_snippet": file_last_diff.get(f["file"], {}).get("diff", "")[:400],
+            }
+            for f in risky_files
+        ],
+        "domain_counts": domain_counts,
+        "ai_weak_domains": ai_vs_human.get("ai", {}).get("weak_domains", []),
+        "clusters": [
+            {
+                "start": c.get("start"),
+                "end": c.get("end"),
+                "size": c.get("size"),
+                "domain": c.get("domain"),
+            }
+            for c in clusters
+        ],
+    }
+
+
 # ── 리포트 출력 ──────────────────────────────────────────────────────────────
 def print_report(
     prs: list[PR],

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -52,9 +52,13 @@ def load_history() -> dict:
 def _check_risk_zones(file_paths: list[str], repo: str | None = None) -> str:
     """
     편집하려는 파일들이 과거 회귀 핫존인지 확인.
-    repo 지정 시 해당 레포 캐시만 조회. 미지정 시 등록된 첫 번째 레포 사용.
+    repo 지정 시 해당 레포 캐시만 조회. 미지정 시 등록 레포가 1개면 자동 선택,
+    2개 이상이면 ValueError → 사용자에게 명시 요청.
     """
-    cache = load_cache(repo)
+    try:
+        cache = load_cache(repo)
+    except ValueError as e:
+        return f"⚠️ {e}"
     if not cache:
         return (
             "⚠️ 캐시 없음 — `analyze_pr_history`를 먼저 실행하거나 "
@@ -215,34 +219,28 @@ def _analyze_pr_history(repo: str, limit: int = 200) -> str:
     fix_count = sum(1 for p in prs if p.is_fix)
     fix_rate = round(fix_count / total * 100, 1) if total else 0
 
-    # 파일별 마지막 fix diff 인덱스 구성
-    file_last_diff: dict[str, dict] = {}
-    for pr in sorted(prs, key=lambda p: p.number):
-        if pr.is_fix and pr.diff_snippet:
-            for f in pr.files:
-                file_last_diff[f] = {"title": pr.title, "diff": pr.diff_snippet}
-
-    # 캐시 저장
-    DATA_DIR.mkdir(exist_ok=True)
-    cache = {
-        "generated_at": __import__("datetime").date.today().isoformat(),
-        "repo": repo,
-        "fix_rate": fix_rate,
-        "risky_files": [
-            {
-                "file": f,
-                "fix_count": n,
-                "domain": ana.classify_domain("", [f]),
-                "last_fix_title": file_last_diff.get(f, {}).get("title", ""),
-                "last_diff_snippet": file_last_diff.get(f, {}).get("diff", "")[:400],
-            }
-            for f, n in risky_files
-        ],
+    # report dict로 정규화 후 ana.build_cache_dict 호출
+    # → evolve-rules.yml Step 1.5와 100% 동일한 스키마 보장 (드리프트 차단)
+    fix_prs_with_diff = [
+        {
+            "number": p.number,
+            "title": p.title,
+            "domain": p.domain,
+            "files": p.files,
+            "diff_snippet": p.diff_snippet,
+        }
+        for p in prs
+        if p.is_fix and p.diff_snippet
+    ]
+    report = {
+        "summary": {"total_prs": total, "fix_prs": fix_count, "fix_rate": fix_rate},
+        "clusters": [{"start": c.start, "end": c.end, "size": c.size, "domain": c.domain} for c in clusters],
+        "risky_files": [{"file": f, "fix_count": n} for f, n in risky_files],
         "domain_counts": [{"domain": d, "fix_count": n} for d, n in domain_counts],
-        "ai_weak_domains": ai_stats["ai"]["weak_domains"],
-        "clusters": [{"start": c.start, "end": c.end, "domain": c.domain} for c in clusters],
+        "ai_vs_human": ai_stats,
+        "fix_prs_with_diff": fix_prs_with_diff,
     }
-    # 레포별 경로에 저장 (멀티 레포 지원)
+    cache = ana.build_cache_dict(report, repo)
     cache_path(repo).write_text(json.dumps(cache, ensure_ascii=False, indent=2))
 
     # 응답 구성

--- a/src/repo_store.py
+++ b/src/repo_store.py
@@ -12,12 +12,18 @@
   data/repos/{slug}/warning-log.jsonl    — PostToolUse 경고 로그
   data/repos/{slug}/feedback-stats.json  — 경고 정밀도 통계
 
+슬러그 정책:
+  '/' → '__' (이중 언더스코어). 'owner_with_underscore/repo' 같은 케이스에서도
+  안전하게 round-trip 가능. 추가로 list_registered_repos()는 슬러그 역변환에
+  의존하지 않고 analysis-cache.json 안의 'repo' 필드를 정답 소스로 사용한다.
+
 하위 호환:
-  data/analysis-cache.json 이 있으면 fallback으로 사용 (v0.x 마이그레이션).
+  data/analysis-cache.json (구버전 단일 레포) 존재 시 fallback으로 사용.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -28,87 +34,122 @@ REPOS_DIR = DATA_DIR / "repos"
 # 하위 호환: 구버전 단일 레포 캐시 경로
 _LEGACY_CACHE = DATA_DIR / "analysis-cache.json"
 
+# detect_current_repo() 결과 캐시 — subprocess 비용 제거
+_REPO_CACHE: dict[str, str | None] = {}
+
 
 def repo_slug(repo: str) -> str:
-    """'owner/repo' → 'owner_repo' (디렉토리명으로 사용 가능한 형태)."""
-    return re.sub(r"[^a-zA-Z0-9._-]", "_", repo)
+    """
+    'owner/repo' → 'owner__repo'. 단일 underscore가 아닌 더블 underscore를 써서
+    owner나 repo 이름에 underscore가 있어도 round-trip 안전.
+    """
+    if "/" not in repo:
+        # 잘못된 형식이면 안전한 문자만 남김
+        return re.sub(r"[^a-zA-Z0-9._-]", "_", repo)
+    return repo.replace("/", "__")
 
 
-def repo_data_dir(repo: str) -> Path:
-    """레포별 데이터 디렉토리. 없으면 자동 생성."""
+def repo_data_dir(repo: str, create: bool = True) -> Path:
+    """
+    레포별 데이터 디렉토리. create=False 면 존재 여부 확인용으로 사용 (mkdir 안 함).
+    """
     path = REPOS_DIR / repo_slug(repo)
-    path.mkdir(parents=True, exist_ok=True)
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
     return path
 
 
-def cache_path(repo: str) -> Path:
-    return repo_data_dir(repo) / "analysis-cache.json"
+def cache_path(repo: str, create: bool = True) -> Path:
+    return repo_data_dir(repo, create=create) / "analysis-cache.json"
 
 
-def warning_log_path(repo: str) -> Path:
-    return repo_data_dir(repo) / "warning-log.jsonl"
+def warning_log_path(repo: str, create: bool = True) -> Path:
+    return repo_data_dir(repo, create=create) / "warning-log.jsonl"
 
 
-def feedback_stats_path(repo: str) -> Path:
-    return repo_data_dir(repo) / "feedback-stats.json"
+def feedback_stats_path(repo: str, create: bool = True) -> Path:
+    return repo_data_dir(repo, create=create) / "feedback-stats.json"
+
+
+def list_registered_repos() -> list[str]:
+    """
+    data/repos/{slug}/analysis-cache.json 안의 'repo' 필드를 정답 소스로 읽는다.
+    슬러그 역변환에 의존하지 않으므로 owner/repo에 underscore가 있어도 안전.
+    """
+    if not REPOS_DIR.exists():
+        return []
+    repos: list[str] = []
+    for d in sorted(REPOS_DIR.iterdir()):
+        if not d.is_dir():
+            continue
+        cache_file = d / "analysis-cache.json"
+        if not cache_file.exists():
+            continue
+        try:
+            data = json.loads(cache_file.read_text())
+            repo_name = data.get("repo")
+            if repo_name:
+                repos.append(repo_name)
+        except Exception:
+            continue
+    return repos
 
 
 def load_cache(repo: str | None = None) -> dict:
     """
-    레포 지정 시 레포별 캐시 로드.
-    미지정 시 등록된 첫 번째 레포 또는 legacy 캐시 fallback.
+    repo 명시 → 해당 레포 캐시 (없으면 빈 dict).
+    repo 미지정:
+      - 등록 레포 0개 + legacy 캐시 존재 → legacy 사용
+      - 등록 레포 1개 → 그것 사용 (모호하지 않음)
+      - 등록 레포 ≥2개 → ValueError (무음 오답 방지)
     """
-    import json
-
     if repo:
-        p = cache_path(repo)
+        p = cache_path(repo, create=False)
         if p.exists():
             return json.loads(p.read_text())
-        # 레포가 지정됐지만 캐시가 없으면 빈 dict (analyze_pr_history 먼저 실행 필요)
         return {}
 
-    # repo 미지정: 등록된 레포 중 첫 번째 사용
     registered = list_registered_repos()
-    for r in registered:
-        p = cache_path(r)
+
+    if len(registered) >= 2:
+        raise ValueError(
+            f"여러 레포가 등록되어 있습니다 ({', '.join(registered)}). "
+            f"repo 파라미터를 명시하세요."
+        )
+
+    if len(registered) == 1:
+        p = cache_path(registered[0], create=False)
         if p.exists():
             return json.loads(p.read_text())
 
     # legacy fallback (v0.x 호환)
     if _LEGACY_CACHE.exists():
-        import json
         return json.loads(_LEGACY_CACHE.read_text())
 
     return {}
 
 
-def list_registered_repos() -> list[str]:
-    """data/repos/ 하위 디렉토리 존재 여부로 등록 레포 목록 반환."""
-    if not REPOS_DIR.exists():
-        return []
-    return [
-        d.name.replace("_", "/", 1)  # slug → owner/repo (첫 번째 _ 만 치환)
-        for d in sorted(REPOS_DIR.iterdir())
-        if d.is_dir() and (d / "analysis-cache.json").exists()
-    ]
-
-
 def detect_current_repo() -> str | None:
     """
     현재 디렉토리의 git remote origin에서 레포 이름을 자동 감지.
-    GitHub URL 형식: https://github.com/owner/repo.git
-                     git@github.com:owner/repo.git
+    결과는 cwd 단위로 캐싱하여 PostToolUse 훅 latency를 줄인다.
     """
+    cwd = str(Path.cwd())
+    if cwd in _REPO_CACHE:
+        return _REPO_CACHE[cwd]
+
+    repo: str | None = None
     try:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True, text=True, timeout=3,
         )
         url = result.stdout.strip()
-        # SSH: git@github.com:owner/repo.git
         m = re.search(r"github\.com[:/]([^/]+/[^/]+?)(?:\.git)?$", url)
         if m:
-            return m.group(1)
+            repo = m.group(1)
     except Exception:
         pass
-    return None
+
+    _REPO_CACHE[cwd] = repo
+    return repo

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -377,3 +377,52 @@ def test_time_window_malformed_date_fallback():
     ]
     clusters = detect_clusters(prs, window=14, threshold=2)
     assert len(clusters) == 1  # both fall to epoch, so they're in the same window
+
+
+# ── build_cache_dict (mcp_server + evolve-rules.yml 공유 함수) ──────────────
+
+def test_build_cache_dict_basic_fields():
+    """기본 캐시 빌드 — analyze.py JSON 출력 → cache 구조."""
+    from analyze import build_cache_dict
+    report = {
+        "summary": {"total_prs": 100, "fix_prs": 12, "fix_rate": 12.0},
+        "clusters": [{"start": 10, "end": 20, "size": 3, "domain": "ci/cd"}],
+        "risky_files": [{"file": "src/lib/auth.ts", "fix_count": 5}],
+        "domain_counts": [{"domain": "auth", "fix_count": 5}],
+        "ai_vs_human": {"ai": {"weak_domains": [{"domain": "auth", "count": 3}]}},
+        "fix_prs_with_diff": [
+            {"number": 42, "title": "fix: auth", "domain": "auth",
+             "files": ["src/lib/auth.ts"], "diff_snippet": "diff content"}
+        ],
+    }
+    cache = build_cache_dict(report, "owner/repo")
+
+    assert cache["repo"] == "owner/repo"
+    assert cache["fix_rate"] == 12.0
+    assert cache["risky_files"][0]["file"] == "src/lib/auth.ts"
+    assert cache["risky_files"][0]["fix_count"] == 5
+    # 마지막 fix diff가 risky_files에 매칭됨
+    assert cache["risky_files"][0]["last_fix_title"] == "fix: auth"
+    assert "diff content" in cache["risky_files"][0]["last_diff_snippet"]
+
+
+def test_build_cache_dict_uses_fix_count_not_count():
+    """analyze.py JSON 출력은 'fix_count' 키를 쓰며 'count'를 쓰지 않는다 (회귀 방지)."""
+    from analyze import build_cache_dict
+    report = {
+        "summary": {"fix_rate": 5.0},
+        "risky_files": [{"file": "x.ts", "fix_count": 7}],
+        "fix_prs_with_diff": [],
+    }
+    cache = build_cache_dict(report, "test/repo")
+    # KeyError 없이 동작하면 OK
+    assert cache["risky_files"][0]["fix_count"] == 7
+
+
+def test_build_cache_dict_empty_report():
+    """비어있는 report도 안전하게 처리."""
+    from analyze import build_cache_dict
+    cache = build_cache_dict({}, "empty/repo")
+    assert cache["repo"] == "empty/repo"
+    assert cache["risky_files"] == []
+    assert cache["clusters"] == []

--- a/tests/test_repo_store.py
+++ b/tests/test_repo_store.py
@@ -1,0 +1,170 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import repo_store
+
+
+# ── repo_slug ─────────────────────────────────────────────────────────────────
+
+def test_repo_slug_basic():
+    assert repo_store.repo_slug("owner/repo") == "owner__repo"
+
+
+def test_repo_slug_underscore_in_owner():
+    """이중 underscore 슬러그는 owner에 underscore가 있어도 round-trip 안전."""
+    assert repo_store.repo_slug("my_org/my-repo") == "my_org__my-repo"
+
+
+def test_repo_slug_no_collision():
+    """과거 단일 underscore 슬러그가 일으켰던 충돌이 발생하지 않는다."""
+    a = repo_store.repo_slug("owner/repo_a")
+    b = repo_store.repo_slug("owner_repo/a")
+    assert a != b
+
+
+def test_repo_slug_invalid_format():
+    """슬래시 없는 입력도 안전한 문자만 남김."""
+    assert "/" not in repo_store.repo_slug("just-a-name")
+
+
+# ── list_registered_repos ─────────────────────────────────────────────────────
+
+def test_list_registered_repos_reads_from_cache_field(tmp_path, monkeypatch):
+    """슬러그 역변환에 의존하지 않고 cache 안의 'repo' 필드를 읽는다."""
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    repos_dir = tmp_path / "repos"
+    repos_dir.mkdir()
+
+    # owner에 underscore가 들어간 케이스도 정확히 복원돼야 함
+    slug_dir = repos_dir / "my_org__my-repo"
+    slug_dir.mkdir()
+    (slug_dir / "analysis-cache.json").write_text(
+        json.dumps({"repo": "my_org/my-repo", "fix_rate": 10})
+    )
+
+    result = repo_store.list_registered_repos()
+    assert "my_org/my-repo" in result
+
+
+def test_list_registered_repos_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    assert repo_store.list_registered_repos() == []
+
+
+def test_list_registered_repos_skips_dirs_without_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    repos_dir = tmp_path / "repos"
+    repos_dir.mkdir()
+    (repos_dir / "empty_dir").mkdir()  # cache 파일 없음
+    assert repo_store.list_registered_repos() == []
+
+
+# ── load_cache ────────────────────────────────────────────────────────────────
+
+def test_load_cache_specific_repo(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    monkeypatch.setattr(repo_store, "_LEGACY_CACHE", tmp_path / "legacy.json")
+
+    repos_dir = tmp_path / "repos"
+    repos_dir.mkdir()
+    (repos_dir / "owner__repo").mkdir()
+    (repos_dir / "owner__repo" / "analysis-cache.json").write_text(
+        json.dumps({"repo": "owner/repo", "fix_rate": 12.5})
+    )
+
+    cache = repo_store.load_cache("owner/repo")
+    assert cache["fix_rate"] == 12.5
+
+
+def test_load_cache_unspecified_with_one_repo(tmp_path, monkeypatch):
+    """등록 레포 1개면 무엇을 의미하는지 모호하지 않으므로 자동 선택."""
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    monkeypatch.setattr(repo_store, "_LEGACY_CACHE", tmp_path / "legacy.json")
+
+    repos_dir = tmp_path / "repos"
+    repos_dir.mkdir()
+    (repos_dir / "owner__repo").mkdir()
+    (repos_dir / "owner__repo" / "analysis-cache.json").write_text(
+        json.dumps({"repo": "owner/repo", "fix_rate": 8.1})
+    )
+
+    cache = repo_store.load_cache(None)
+    assert cache["fix_rate"] == 8.1
+
+
+def test_load_cache_unspecified_with_multiple_repos_raises(tmp_path, monkeypatch):
+    """등록 레포 ≥2 + repo 미지정 → ValueError (무음 오답 차단)."""
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    monkeypatch.setattr(repo_store, "_LEGACY_CACHE", tmp_path / "legacy.json")
+
+    repos_dir = tmp_path / "repos"
+    repos_dir.mkdir()
+    for slug, repo in [("owner__a", "owner/a"), ("owner__b", "owner/b")]:
+        (repos_dir / slug).mkdir()
+        (repos_dir / slug / "analysis-cache.json").write_text(
+            json.dumps({"repo": repo})
+        )
+
+    with pytest.raises(ValueError, match="여러 레포"):
+        repo_store.load_cache(None)
+
+
+def test_load_cache_legacy_fallback(tmp_path, monkeypatch):
+    """등록 레포 0개 + legacy 캐시 존재 → legacy 사용."""
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    legacy = tmp_path / "legacy.json"
+    legacy.write_text(json.dumps({"repo": "old/repo", "fix_rate": 99}))
+    monkeypatch.setattr(repo_store, "_LEGACY_CACHE", legacy)
+
+    cache = repo_store.load_cache(None)
+    assert cache["fix_rate"] == 99
+
+
+def test_load_cache_missing_repo_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    monkeypatch.setattr(repo_store, "_LEGACY_CACHE", tmp_path / "legacy.json")
+    assert repo_store.load_cache("nobody/nothing") == {}
+
+
+# ── repo_data_dir create=False ────────────────────────────────────────────────
+
+def test_repo_data_dir_create_false_does_not_mkdir(tmp_path, monkeypatch):
+    """read 경로에서는 phantom 디렉토리를 만들지 않는다."""
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    p = repo_store.repo_data_dir("phantom/repo", create=False)
+    assert not p.exists()
+
+
+def test_repo_data_dir_create_true_does_mkdir(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_store, "REPOS_DIR", tmp_path / "repos")
+    p = repo_store.repo_data_dir("real/repo", create=True)
+    assert p.exists()
+
+
+# ── detect_current_repo 캐싱 ──────────────────────────────────────────────────
+
+def test_detect_current_repo_caches_result(monkeypatch):
+    """동일 cwd에서 두 번째 호출은 subprocess를 안 돈다."""
+    repo_store._REPO_CACHE.clear()
+    call_count = [0]
+
+    class FakeResult:
+        stdout = "https://github.com/owner/repo.git\n"
+
+    def fake_run(*args, **kwargs):
+        call_count[0] += 1
+        return FakeResult()
+
+    monkeypatch.setattr(repo_store.subprocess, "run", fake_run)
+
+    r1 = repo_store.detect_current_repo()
+    r2 = repo_store.detect_current_repo()
+
+    assert r1 == r2 == "owner/repo"
+    assert call_count[0] == 1  # 두 번째는 캐시 히트


### PR DESCRIPTION
## Summary

PR #27 (멀티 레포 확장) 사후 검토에서 발견된 7개 이슈를 모두 수정.

> 머지 전 사용자 검토 대기 중. 자동 머지 안 함.

## CRITICAL — 다음 실행 시 즉시 깨짐

### Bug #1: Step 1.5 `f['count']` KeyError
`analyze.py`는 `{"file": f, "fix_count": n}`를 출력하는데 Step 1.5는 `f['count']` 사용. 첫 실행 즉시 KeyError.

**Fix**: `analyze.build_cache_dict()` 공유 함수로 캐시 빌드를 위임 (mcp_server와 동일 함수 사용 → 스키마 드리프트 차단).

### Bug #2: Step 3.6 피드백 평가 영구 죽음
- `Path("data/warning-log.jsonl")` 체크 → rag_hook은 `data/repos/{slug}/warning-log.jsonl`에 씀 → 항상 스킵
- `evaluate(fix_prs)`만 호출 → repo 미전달 → GH 러너 git remote(=ai-dev-loop-analyzer) 잘못 감지

**Fix**: `warning_log_path(target_repo)` 사용 + `evaluate(fix_prs, repo=target_repo)`로 명시 + `TARGET_REPO` env var 추가.

### Bug #3: `load_cache(repo=None)` 무음 오답
등록 레포 ≥2개일 때 알파벳 첫 레포의 데이터를 조용히 반환 → 사용자는 잘못된 경고 받음.

**Fix**: 등록 레포 ≥2이고 repo 미지정 시 `ValueError` 발생. 1개일 때는 모호하지 않으므로 자동 선택 유지.

## HIGH — 설계 결함

### Bug #4: 슬러그 round-trip 손실
`my_org/repo` → `my_org_repo` → 역변환 → `my/org_repo` ❌

**Fix**: `/` → `__` (이중 underscore). owner에 underscore가 있어도 안전.

### Bug #5: 슬러그 충돌
`owner/repo_a` vs `owner_repo/a` 모두 `owner_repo_a`로 매핑되어 같은 디렉토리 공유.

**Fix**: 이중 underscore 슬러그 + `list_registered_repos()`가 슬러그 역변환 대신 `analysis-cache.json` 안의 `repo` 필드를 정답 소스로 사용.

### Bug #6: Step 1.5 프로파일 미로드
`classify_domain()` 호출하지만 `AI_DEV_LOOP_PROFILE`을 안 받아 기본 패턴만 사용 → gwangcheon-shop 한국어 키워드가 안 먹어 도메인 죄다 `general`.

**Fix**: Step 1.5에 `AI_DEV_LOOP_PROFILE` env var 추가 + 명시적 `ana.load_profile()` 호출.

### Bug #7: 캐시 스키마 드리프트
mcp_server.py와 Step 1.5가 각자 cache dict 빌드 → 스키마가 다름.

**Fix**: `analyze.build_cache_dict(report, repo)` 단일 함수로 통합. mcp_server는 prs를 report dict로 정규화한 뒤 같은 함수 호출.

## MEDIUM

- **#8 subprocess 캐싱**: `detect_current_repo()` 결과를 cwd 키로 module-level 캐싱 → PostToolUse 훅 latency 50–100ms 절감
- **#9 phantom mkdir**: `repo_data_dir(create=False)` 옵션 추가 → 읽기 경로에서 빈 디렉토리 안 만듦
- **#10 마이그레이션**: `scripts/migrate_to_multi_repo.py` 추가 — `data/analysis-cache.json`(legacy) → `data/repos/{slug}/`로 이전, `--dry-run` 지원

## 테스트 (#13 해결)

신규 18개:
- `test_repo_store.py` 15개 — 슬러그 충돌 방지, round-trip 안전성, ValueError 동작, legacy fallback, mkdir 부수효과 차단, subprocess 캐싱
- `test_analyze.py` 3개 — `build_cache_dict` 기본 필드, `fix_count` 키 사용 회귀 방지, 빈 report 안전 처리

전체 65개 테스트 통과 (기존 47 + 신규 18).

## .gitignore 업데이트

`*.json` 글로벌 ignore가 멀티 레포 캐시도 막던 문제:

```
!data/repos/                                ← 디렉토리 화이트리스트
!data/repos/**/analysis-cache.json          ← 추적
!data/repos/**/feedback-stats.json          ← 추적
data/repos/**/warning-log.jsonl             ← 로컬 only (write-heavy, 머신마다 다름)
```

## Test plan

- [x] 65/65 pytest 통과
- [x] `migrate_to_multi_repo.py --dry-run` 동작 확인
- [x] `.gitignore` 패턴이 의도대로 매칭
- [ ] **사용자 검토 대기** — 머지 안 함, 추후 검증 후 진행

## 미해결 (의도적 보류)

- **피드백 루프 cross-machine 동기화**: rag_hook은 dev 머신에서 warning-log.jsonl 쓰지만, evolve-rules는 GH Actions에서 실행 → 서로 보이지 않음. 별도 설계 PR 필요 (현재 warning-log는 local only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)