### PR TITLE
feat(workflow): multi-repo matrix pipeline with issue-creation guard

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -8,11 +8,12 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 1 * * *'   # 매일 오전 10시 KST
+    - cron: '0 1 * * *'   # 매일 오전 10시 KST — schedule="daily" 레포만
+    - cron: '0 2 * * 0'   # 매주 일요일 KST 11시 — schedule="weekly" 레포만
   workflow_dispatch:
     inputs:
       target_repo:
-        description: '분석할 레포 (예: owner/repo). 미입력 시 vars.TARGET_REPO 사용.'
+        description: '특정 레포만 분석 (예: owner/repo). 미입력 시 enabled 레포 전체.'
         required: false
         default: ''
       dry_run:
@@ -27,14 +28,68 @@ on:
     types: [pr-merged]
 
 jobs:
-  evolve:
+  # ── setup-matrix: config/repos.json → 트리거별 동적 매트릭스 ────────────────
+  # 트리거 분기:
+  #   - schedule '0 1 * * *' → schedule="daily" + enabled
+  #   - schedule '0 2 * * 0' → schedule="weekly" + enabled
+  #   - workflow_dispatch with target_repo → 그 레포만 (enabled 무시 — 디버깅용)
+  #   - workflow_dispatch without target_repo → enabled 전체
+  #   - repository_dispatch → client_payload.repo (없으면 gwangcheon-shop)
+  setup-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+      count: ${{ steps.set.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: set
+        env:
+          INPUT_REPO: ${{ inputs.target_repo }}
+          DISPATCH_REPO: ${{ github.event.client_payload.repo }}
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+        run: |
+          set -e
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_REPO" ]; then
+            MATRIX=$(jq --arg r "$INPUT_REPO" -c '[.[] | select(.repo == $r)]' config/repos.json)
+          elif [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            REPO="${DISPATCH_REPO:-rladmsgh34/gwangcheon-shop}"
+            MATRIX=$(jq --arg r "$REPO" -c '[.[] | select(.repo == $r and .enabled == true)]' config/repos.json)
+          elif [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULE" = "0 2 * * 0" ]; then
+            MATRIX=$(jq -c '[.[] | select(.schedule == "weekly" and .enabled == true)]' config/repos.json)
+          elif [ "$EVENT_NAME" = "schedule" ]; then
+            MATRIX=$(jq -c '[.[] | select(.schedule == "daily" and .enabled == true)]' config/repos.json)
+          else
+            MATRIX=$(jq -c '[.[] | select(.enabled == true)]' config/repos.json)
+          fi
+          COUNT=$(echo "$MATRIX" | jq 'length')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "── selected ${COUNT} repo(s) ──"
+          echo "$MATRIX" | jq '.'
+
+  evolve:
+    needs: setup-matrix
+    if: needs.setup-matrix.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      # max-parallel: 1 — analyze.py에 incremental fetch가 없어 매번 fetch_limit만큼
+      # gh API를 소비함. 직렬 실행으로 GITHUB_TOKEN(1000/hr) / GH_PAT(5000/hr) 한도 보호.
+      max-parallel: 1
+      # fail-fast: false — 한 레포가 실패해도 나머지는 계속 진행.
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
     env:
-      TARGET_REPO: ${{ inputs.target_repo || vars.TARGET_REPO || 'rladmsgh34/gwangcheon-shop' }}
+      TARGET_REPO: ${{ matrix.target.repo }}
+      POST_ISSUES: ${{ matrix.target.post_issues }}
+      FETCH_LIMIT: ${{ matrix.target.fetch_limit }}
+      PROFILE_PATH: ${{ matrix.target.profile }}
       IS_PR_TRIGGER: ${{ github.event_name == 'repository_dispatch' }}
 
     steps:
@@ -60,19 +115,35 @@ jobs:
           path: target-repo
 
       # ── Step 1: analyze ─────────────────────────────────────────────────────
+      # 프로파일 우선순위:
+      #   1. matrix.target.profile (config/repos.json) — 명시적 override
+      #   2. target-repo/.claude/ai-dev-loop-profile.json — 타겟 레포 자체 보유
+      #   3. 없으면 src/analyze.py의 built-in default
       - name: Collect and analyze PR history
         id: analyze
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          AI_DEV_LOOP_PROFILE: target-repo/.claude/ai-dev-loop-profile.json
         run: |
-          LIMIT=300
+          set -e
+          LIMIT="$FETCH_LIMIT"
           FETCH_FLAG="--fetch-files"
           if [ "$IS_PR_TRIGGER" = "true" ]; then
             LIMIT=50
             FETCH_FLAG=""
           elif [ "${{ inputs.fetch_files }}" = "false" ]; then
             FETCH_FLAG=""
+          fi
+
+          # 프로파일 결정 — 파일 존재 시에만 --profile 전달
+          PROFILE_FLAG=""
+          if [ -n "$PROFILE_PATH" ] && [ -f "$PROFILE_PATH" ]; then
+            PROFILE_FLAG="--profile $PROFILE_PATH"
+            echo "profile: $PROFILE_PATH (matrix override)"
+          elif [ -f "target-repo/.claude/ai-dev-loop-profile.json" ]; then
+            PROFILE_FLAG="--profile target-repo/.claude/ai-dev-loop-profile.json"
+            echo "profile: target-repo in-tree"
+          else
+            echo "profile: built-in default"
           fi
 
           gh pr list \
@@ -85,6 +156,7 @@ jobs:
             --input /tmp/prs.json \
             --github-token "$GH_TOKEN" \
             --format json \
+            $PROFILE_FLAG \
             $FETCH_FLAG \
             2>/dev/null > /tmp/report.json
 
@@ -94,14 +166,14 @@ jobs:
           echo "cluster_count=$CLUSTER_COUNT" >> $GITHUB_OUTPUT
           echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
           echo "is_pr_trigger=$IS_PR_TRIGGER" >> $GITHUB_OUTPUT
+          echo "profile_flag=$PROFILE_FLAG" >> $GITHUB_OUTPUT
 
       # ── Step 1.5: analysis-cache 레포별 경로에 저장 ──────────────────────────
       # 캐시 빌드는 analyze.build_cache_dict()로 위임 (mcp_server와 동일 함수 사용 → 스키마 드리프트 차단).
-      # 도메인 분류 정확도를 위해 AI_DEV_LOOP_PROFILE을 명시적으로 전달.
       - name: Save analysis cache to per-repo directory
         env:
           TARGET_REPO: ${{ env.TARGET_REPO }}
-          AI_DEV_LOOP_PROFILE: target-repo/.claude/ai-dev-loop-profile.json
+          PROFILE_PATH: ${{ env.PROFILE_PATH }}
         run: |
           python3 - <<'PYEOF'
           import json, os, sys
@@ -114,8 +186,13 @@ jobs:
               sys.exit(0)
 
           import analyze as ana
-          profile_path = os.environ.get('AI_DEV_LOOP_PROFILE')
-          if profile_path and Path(profile_path).exists():
+
+          # 프로파일: matrix override 우선, 없으면 target-repo in-tree
+          profile_path = os.environ.get('PROFILE_PATH') or ''
+          if not profile_path or not Path(profile_path).exists():
+              fallback = 'target-repo/.claude/ai-dev-loop-profile.json'
+              profile_path = fallback if Path(fallback).exists() else ''
+          if profile_path:
               ana.load_profile(profile_path)
               print(f'프로파일 로드: {profile_path}')
 
@@ -128,9 +205,10 @@ jobs:
           print(f'✅ analysis-cache 저장: {p}')
           PYEOF
 
-      # ── Step 2: issue report ───────────────────────────────────────────────
+      # ── Step 2: 일일 리포트 (analyzer 자체 레포에 issue) ───────────────────
+      # 외부 레포(post_issues=false)는 일일 리포트 노이즈가 의미 없으므로 스킵.
       - name: Post daily report issue
-        if: env.IS_PR_TRIGGER != 'true'
+        if: env.IS_PR_TRIGGER != 'true' && env.POST_ISSUES == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,9 +220,10 @@ jobs:
           d = json.load(open('/tmp/report.json'))
           s = d['summary']
           date = os.environ.get('REPORT_DATE', '')
+          target_repo = os.environ.get('TARGET_REPO', '')
 
           lines = [
-            f"## 📊 일일 PR 품질 리포트 — {date}",
+            f"## 📊 일일 PR 품질 리포트 — {date} ({target_repo})",
             "",
             f"**총 PR**: {s['total_prs']}개 | **fix PR**: {s['fix_prs']}개 ({s['fix_rate']}%)",
             "",
@@ -177,18 +256,19 @@ jobs:
             for r in rules:
               lines.append(r)
 
-          lines += ["---", f"_[ai-dev-loop-analyzer](https://github.com/rladmsgh34/ai-dev-loop-analyzer) · {date}_"]
+          lines += ["---", f"_[ai-dev-loop-analyzer](https://github.com/rladmsgh34/ai-dev-loop-analyzer) · {date} · {target_repo}_"]
 
           body = "\n".join(lines)
-          title = f"[일일 리포트] {date} — fix율 {s['fix_rate']}%"
+          title = f"[일일 리포트] {date} — {target_repo} fix율 {s['fix_rate']}%"
 
           existing = json.loads(subprocess.run(
             ['gh', 'issue', 'list', '--label', 'daily-report', '--state', 'open',
-             '--json', 'number,title', '--limit', '5'],
+             '--json', 'number,title', '--limit', '20'],
             capture_output=True, text=True
           ).stdout or '[]')
 
-          today_issue = next((i for i in existing if date in i['title']), None)
+          # 같은 날 + 같은 타겟의 이슈만 갱신 (다른 타겟은 별개 이슈로 유지)
+          today_issue = next((i for i in existing if date in i['title'] and target_repo in i['title']), None)
           if today_issue:
             subprocess.run(['gh', 'issue', 'edit', str(today_issue['number']),
                             '--title', title, '--body', body], check=True)
@@ -197,9 +277,11 @@ jobs:
                             '--body', body, '--label', 'daily-report'], check=True)
           PYEOF
 
-      # ── Step 2b: gwangcheon-shop 회귀 경고 이슈 생성 ────────────────────────
-      - name: gwangcheon-shop에 회귀 경고 이슈 생성
-        if: env.IS_PR_TRIGGER != 'true'
+      # ── Step 2b: 타겟 레포에 회귀 경고 이슈 생성 ────────────────────────────
+      # 🚨 핵심 안전판 — post_issues=true (rladmsgh34/* 같은 owned 레포)일 때만 실행.
+      # 외부 레포(vuejs/core, vercel/next.js 등)에는 절대 이슈가 생성되지 않도록 보호.
+      - name: 타겟 레포에 회귀 경고 이슈 생성
+        if: env.IS_PR_TRIGGER != 'true' && env.POST_ISSUES == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -248,7 +330,6 @@ jobs:
               )
 
           # ── 대표 도메인 선택 ──────────────────────────────────────────────
-          # 클러스터 있으면 가장 큰 클러스터 도메인, 없으면 hot_domain 1위
           if clusters:
               top_cluster = max(clusters, key=lambda c: c['size'])
               rep_domain = top_cluster['domain']
@@ -333,7 +414,6 @@ jobs:
           )
 
           if today_issue:
-              # 이미 같은 날 같은 도메인 이슈 존재 → 댓글 추가
               comment_body = f"## \U0001f504 업데이트 ({date})\n\n{body}"
               subprocess.run(
                   ['gh', 'issue', 'comment', str(today_issue['number']),
@@ -343,7 +423,6 @@ jobs:
               )
               print(f"기존 이슈 #{today_issue['number']}에 댓글 추가 완료")
           else:
-              # 신규 이슈 생성
               result = subprocess.run(
                   ['gh', 'issue', 'create',
                    '--repo', target_repo,
@@ -354,7 +433,7 @@ jobs:
                   capture_output=True, text=True
               )
               if result.returncode == 0:
-                  print(f"gwangcheon-shop 이슈 생성 완료: {result.stdout.strip()}")
+                  print(f"타겟 레포 이슈 생성 완료: {result.stdout.strip()}")
               else:
                   print(f"이슈 생성 실패: {result.stderr}", file=sys.stderr)
                   sys.exit(1)
@@ -427,7 +506,7 @@ jobs:
                   "title": pr.get("title", ""),
                   "domain": pr.get("domain", "general"),
                   "files": pr.get("files", []),
-                  "diff_snippet": diff[:800],  # 800자 제한
+                  "diff_snippet": diff[:800],
                   "date": date,
               })
               new_count += 1
@@ -444,9 +523,6 @@ jobs:
           TARGET_REPO: ${{ env.TARGET_REPO }}
 
       # ── Step 3.6: 피드백 루프 — 경고 로그 vs fix PR 교차 검증 ─────────────
-      # rag_hook.py가 data/repos/{slug}/warning-log.jsonl에 기록한 경고를
-      # 같은 레포의 fix PR과 대조해 TP/FP 판정. 반드시 TARGET_REPO를 명시해야
-      # GH 러너 git remote(=ai-dev-loop-analyzer)를 잘못 감지하지 않음.
       - name: 경고 피드백 정밀도 평가
         continue-on-error: true
         env:
@@ -486,21 +562,34 @@ jobs:
         env:
           TARGET_REPO: ${{ env.TARGET_REPO }}
         run: |
+          set -e
           git config user.name "ai-dev-loop-analyzer[bot]"
           git config user.email "ai-dev-loop-analyzer@users.noreply.github.com"
           REPO_SLUG=$(echo "$TARGET_REPO" | tr '/' '_')
-          # 공유 데이터 + 레포별 데이터 모두 커밋
+          # 직렬 매트릭스라 매 iteration마다 새 checkout이지만, 이전 iteration 커밋과의
+          # 충돌 방지를 위해 push 전에 한 번 더 rebase. 실패 시 한 번만 재시도.
           git add data/rules-history.json data/diff-patterns.json || true
           git add "data/repos/${REPO_SLUG}/" || true
-          git diff --staged --quiet || git commit -m "data: daily snapshot ${{ steps.analyze.outputs.date }} [${TARGET_REPO}]"
-          git push
+          if git diff --staged --quiet; then
+            echo "변경 없음 — 커밋 스킵"
+            exit 0
+          fi
+          git commit -m "data: daily snapshot ${{ steps.analyze.outputs.date }} [${TARGET_REPO}]"
+          git pull --rebase origin main || true
+          git push || (sleep 5 && git pull --rebase origin main && git push)
 
       # ── Step 4: patch CLAUDE.md ────────────────────────────────────────────
+      # 외부 레포는 CLAUDE.md를 보유하지 않거나 우리가 PR을 보낼 권한이 없으므로 스킵.
       - name: Generate CLAUDE.md patch
-        if: env.IS_PR_TRIGGER != 'true'
+        if: env.IS_PR_TRIGGER != 'true' && env.POST_ISSUES == 'true'
         continue-on-error: true
         id: patch
         run: |
+          if [ ! -f target-repo/CLAUDE.md ]; then
+            echo "target-repo/CLAUDE.md 없음 — 스킵"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           python3 src/patch_claude_md.py \
             --report /tmp/report.json \
             --claude-md target-repo/CLAUDE.md \
@@ -516,7 +605,7 @@ jobs:
 
       # ── Step 4b: open PR (only when dry_run=false and changes exist) ────────
       - name: Open target repo PR
-        if: steps.patch.outputs.has_changes == 'true' && inputs.dry_run != 'true'
+        if: env.POST_ISSUES == 'true' && steps.patch.outputs.has_changes == 'true' && inputs.dry_run != 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -93,8 +93,12 @@ jobs:
       IS_PR_TRIGGER: ${{ github.event_name == 'repository_dispatch' }}
 
     steps:
+      # ref 명시 — 기본값(detached HEAD)이면 뒤의 git push가 "not currently on a branch"로 실패.
+      # workflow_dispatch가 PR 브랜치에서 dry-run으로 트리거될 수도 있어 head_ref 우선.
       - name: Checkout ai-dev-loop-analyzer
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       # ── Step 0: prerequisites ───────────────────────────────────────────────
       - name: Ensure labels and data directory
@@ -566,8 +570,6 @@ jobs:
           git config user.name "ai-dev-loop-analyzer[bot]"
           git config user.email "ai-dev-loop-analyzer@users.noreply.github.com"
           REPO_SLUG=$(echo "$TARGET_REPO" | tr '/' '_')
-          # 직렬 매트릭스라 매 iteration마다 새 checkout이지만, 이전 iteration 커밋과의
-          # 충돌 방지를 위해 push 전에 한 번 더 rebase. 실패 시 한 번만 재시도.
           git add data/rules-history.json data/diff-patterns.json || true
           git add "data/repos/${REPO_SLUG}/" || true
           if git diff --staged --quiet; then
@@ -575,8 +577,10 @@ jobs:
             exit 0
           fi
           git commit -m "data: daily snapshot ${{ steps.analyze.outputs.date }} [${TARGET_REPO}]"
-          git pull --rebase origin main || true
-          git push || (sleep 5 && git pull --rebase origin main && git push)
+          # max-parallel:1 + serial matrix면 race가 없지만, 별도 워크플로우 run이
+          # 같은 브랜치에 push했을 가능성에 대비해 충돌 시 한 번만 rebase 재시도.
+          BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+          git push origin "$BRANCH" || (git pull --rebase origin "$BRANCH" && git push origin "$BRANCH")
 
       # ── Step 4: patch CLAUDE.md ────────────────────────────────────────────
       # 외부 레포는 CLAUDE.md를 보유하지 않거나 우리가 PR을 보낼 권한이 없으므로 스킵.

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ __pycache__/
 !data/repos/**/feedback-stats.json
 data/repos/**/warning-log.jsonl
 !profiles/**/*.json
+!config/repos.json
 .DS_Store
 data/chroma/

--- a/config/repos.json
+++ b/config/repos.json
@@ -1,0 +1,26 @@
+[
+  {
+    "repo": "rladmsgh34/gwangcheon-shop",
+    "profile": null,
+    "schedule": "daily",
+    "post_issues": true,
+    "fetch_limit": 300,
+    "enabled": true
+  },
+  {
+    "repo": "vuejs/core",
+    "profile": "profiles/examples/vuejs-core.json",
+    "schedule": "weekly",
+    "post_issues": false,
+    "fetch_limit": 200,
+    "enabled": true
+  },
+  {
+    "repo": "vercel/next.js",
+    "profile": "profiles/examples/vercel-nextjs.json",
+    "schedule": "weekly",
+    "post_issues": false,
+    "fetch_limit": 200,
+    "enabled": true
+  }
+]

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -33,6 +33,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -69,6 +82,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -105,6 +131,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -141,6 +180,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -177,6 +229,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -201,7 +266,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "a13e1029",
@@ -224,7 +303,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "8607b6a2",
@@ -247,7 +340,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "aeaaa483",
@@ -270,7 +377,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "be61b6cd",
@@ -293,26 +414,131 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
+    },
+    {
+      "id": "53a34351",
+      "rule": "- PR에 관련된 `type-only ExportNamed` 기능이 변경될 때는 반드시 관련 테스트를 확인하고 추가해야 한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "7a741814",
+      "rule": "- `devlow-bench`와 같은 설정 파일의 `rootDir` 값이 `package.json`과 불일치할 경우, 수정 전에 영향을 받는 모든 파일을 점검해야 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "af1a86d6",
+      "rule": "- `next/image`의 `images.maximumResponseBody` 설정이 로컬 이미지에도 적용되도록 변화를 줄 경우, 관련된 모든 경우의 수를 테스트하여 누락된 부분이 없는지 확인해야 한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "ca8aa38f",
+      "rule": "- CI/CD 관련 PR에서는 Docker 이미지 캐시와 관련된 변경사항이 있을 때, 성능 측정을 위한 벤치마크 테스트를 반드시 수행해야 한다.",
+      "domain": "ci/cd",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "ab744e04",
+      "rule": "- `cache-components.test.ts`와 같이 테스트 파일에서 발생하는 타입 오류를 사전에 예방하기 위해, 개발 중에 정적 타입 검사 도구를 적극 활용해야 한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
       "snapshots": []
     }
   ],
   "snapshots": [
     {
       "date": "2026-04-26",
-      "total_fix_rate": 58.5,
-      "vapor": 22.0,
+      "total_fix_rate": 17.5,
       "general": 12.5,
-      "compiler": 9.5,
-      "runtime": 3.5,
-      "hydration": 3.0,
-      "types": 2.0,
-      "reactivity": 1.5,
-      "maintenance": 1.0,
-      "ssr": 1.0,
-      "hmr": 1.0,
-      "playground": 0.5,
-      "docs": 0.5,
-      "runtime-dom": 0.5
+      "monorepo": 1.0,
+      "ci/cd": 1.0,
+      "font": 0.5,
+      "cache": 0.5,
+      "maintenance": 0.5,
+      "scripts": 0.5,
+      "cli": 0.5,
+      "test/e2e": 0.5
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -16,7 +16,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "afe62a64",
@@ -34,7 +52,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "09a27d86",
@@ -52,7 +88,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "c6e0595d",
@@ -70,7 +124,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "b89b775d",
@@ -88,21 +160,159 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
+    },
+    {
+      "id": "32699aeb",
+      "rule": "- PR 작성 시, `vapor` 관련 코드 변경이 있을 경우, 연속된 `fix` PR 발행 없이 한 번에 해결하도록 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "a13e1029",
+      "rule": "- `compiler` 관련 코드를 수정할 때는 다른 `fix`와의 종속 관계를 명확히 하고, 관련된 변화가 있는 부분을 모두 수정하여 연쇄적인 `fix` 발생을 예방한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "8607b6a2",
+      "rule": "- `hydration` 작업 시, 유사한 수정사항에 대해 그룹화하여 한번에 수정함으로써 반복적인 `fix`를 줄인다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "aeaaa483",
+      "rule": "- `runtime` 수정 시, 특정 함수 (`createPlainElement`, `hydrate`)의 변경이 있을 경우, 이들 함수와 관련된 모든 속성을 점검하고 수정하여 후속 `fix`를 방지한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "be61b6cd",
+      "rule": "- 동일한 파일에서 `vFor`나 `transition` 관련 수정이 다수 발생할 경우, 여러 이슈를 통합하여 다루도록 하여 반복적인 수정 부담을 줄인다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
       "snapshots": []
     }
   ],
   "snapshots": [
     {
       "date": "2026-04-26",
-      "total_fix_rate": 16.9,
-      "ci/cd": 6.7,
-      "general": 2.2,
-      "external-api": 1.7,
-      "security": 1.7,
-      "payment": 1.7,
-      "database": 1.1,
-      "test/e2e": 1.1,
-      "auth": 0.6
+      "total_fix_rate": 58.5,
+      "vapor": 22.0,
+      "general": 12.5,
+      "compiler": 9.5,
+      "runtime": 3.5,
+      "hydration": 3.0,
+      "types": 2.0,
+      "reactivity": 1.5,
+      "maintenance": 1.0,
+      "ssr": 1.0,
+      "hmr": 1.0,
+      "playground": 0.5,
+      "docs": 0.5,
+      "runtime-dom": 0.5
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -1,4 +1,108 @@
 {
-  "rules": [],
-  "snapshots": []
+  "rules": [
+    {
+      "id": "6b3d2508",
+      "rule": "- src/cli.py에서 위험 파일의 경고를 비활성화하지 않도록 항상 위험도를 확인하고 경고 메시지를 stdout에 출력하세요.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "afe62a64",
+      "rule": "- src/analyze.py의 detect_clusters 함수에서 fix PR 클러스터링 시 window 값을 14로 설정하고, 종속 클러스터를 피하기 위해 이전 클러스터에 포함된 PR을 제외하세요.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "09a27d86",
+      "rule": "- tests/test_analyze.py에서 test 함수의 개별 테스트 케이스를 더 구체적으로 나누어 각 케이스에 대한 명확한 기대 결과를 정의하세요.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "c6e0595d",
+      "rule": "- src/rag_hook.py의 BM25 절대 점수가 _SCORE_THRESHOLD 기준값 1.5 이상이 되도록 새로운 코드 변경 시 기존 패턴과의 유사도를 체크하세요.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "b89b775d",
+      "rule": "- 외부 API 호출이나 보안 관련 코드 변경 시 src/rag_hook.py와 관련된 경고를 추가하여 과거의 회귀 패턴을 인지할 수 있도록 하세요.",
+      "domain": "external-api",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    }
+  ],
+  "snapshots": [
+    {
+      "date": "2026-04-26",
+      "total_fix_rate": 16.9,
+      "ci/cd": 6.7,
+      "general": 2.2,
+      "external-api": 1.7,
+      "security": 1.7,
+      "payment": 1.7,
+      "database": 1.1,
+      "test/e2e": 1.1,
+      "auth": 0.6
+    }
+  ]
 }

--- a/tests/test_repos_config.py
+++ b/tests/test_repos_config.py
@@ -1,0 +1,94 @@
+"""Schema validation for config/repos.json — the single source of truth
+that drives the GitHub Actions matrix in evolve-rules.yml.
+
+Catches drift like missing required fields, wrong types, or duplicate
+repo entries before the workflow fails on a live cron.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / "config" / "repos.json"
+
+REQUIRED_FIELDS = {
+    "repo": str,
+    "profile": (str, type(None)),
+    "schedule": str,
+    "post_issues": bool,
+    "fetch_limit": int,
+    "enabled": bool,
+}
+VALID_SCHEDULES = {"daily", "weekly"}
+
+
+@pytest.fixture(scope="module")
+def repos() -> list[dict]:
+    return json.loads(CONFIG.read_text())
+
+
+def test_top_level_is_list(repos):
+    assert isinstance(repos, list)
+    assert len(repos) > 0, "config/repos.json must declare at least one repo"
+
+
+def test_each_repo_has_required_fields(repos):
+    for entry in repos:
+        for field, expected_type in REQUIRED_FIELDS.items():
+            assert field in entry, f"{entry.get('repo', '?')}: missing '{field}'"
+            assert isinstance(entry[field], expected_type), (
+                f"{entry['repo']}: '{field}' must be {expected_type}, got {type(entry[field])}"
+            )
+
+
+def test_repo_format(repos):
+    for entry in repos:
+        assert "/" in entry["repo"], f"{entry['repo']}: must be 'owner/repo' format"
+
+
+def test_schedule_value(repos):
+    for entry in repos:
+        assert entry["schedule"] in VALID_SCHEDULES, (
+            f"{entry['repo']}: schedule must be one of {VALID_SCHEDULES}"
+        )
+
+
+def test_fetch_limit_sane(repos):
+    for entry in repos:
+        # Lower bound: at least 10 PRs to cluster-detect.
+        # Upper bound: 1500 keeps a single run under the GH_PAT 5000/hr budget
+        # given analyze.py's per-PR API calls (no incremental fetch yet).
+        assert 10 <= entry["fetch_limit"] <= 1500, (
+            f"{entry['repo']}: fetch_limit {entry['fetch_limit']} outside [10, 1500]"
+        )
+
+
+def test_no_duplicate_repos(repos):
+    repo_names = [e["repo"] for e in repos]
+    assert len(repo_names) == len(set(repo_names)), (
+        f"duplicate repo entries: {repo_names}"
+    )
+
+
+def test_external_repos_have_post_issues_false(repos):
+    """🚨 The critical safety guard. External repos must never get auto-issues."""
+    for entry in repos:
+        owner = entry["repo"].split("/")[0]
+        if owner != "rladmsgh34":
+            assert entry["post_issues"] is False, (
+                f"{entry['repo']}: external repo must have post_issues=false "
+                f"(would spam an OSS repo with AI-generated Korean issues)"
+            )
+
+
+def test_profile_paths_exist(repos):
+    for entry in repos:
+        if entry["profile"] is None:
+            continue
+        profile_path = ROOT / entry["profile"]
+        assert profile_path.exists(), (
+            f"{entry['repo']}: profile path '{entry['profile']}' does not exist"
+        )


### PR DESCRIPTION
## Summary
- **`config/repos.json`** = single source of truth for 분석 대상 / 스케줄 / `post_issues` / `fetch_limit` / `enabled`
- **`setup-matrix` job**: jq로 트리거(daily/weekly cron, dispatch, repository_dispatch)별 동적 매트릭스 생성. 빈 매트릭스면 `evolve` job 자체 short-circuit.
- **`evolve` job matrix**: `max-parallel: 1` (analyze.py에 incremental fetch 없어 직렬), `fail-fast: false` (한 레포 실패해도 나머지 진행)
- **🚨 핵심 안전판**: Step 2/2b/4/4b가 모두 `if: env.POST_ISSUES == 'true'` 가드 — 외부 레포(vuejs/core, vercel/next.js)에 한국어 AI 이슈 폭격 절대 차단

## 동작 흐름
| 트리거 | 매트릭스 |
|---|---|
| `cron '0 1 * * *'` | `schedule == "daily" AND enabled` 만 |
| `cron '0 2 * * 0'` | `schedule == "weekly" AND enabled` 만 |
| `workflow_dispatch` (target_repo 지정) | 그 레포 1개 |
| `workflow_dispatch` (target_repo 미지정) | enabled 전체 |
| `repository_dispatch` | `client_payload.repo` (없으면 gwangcheon-shop) |

## 프로파일 우선순위
1. `matrix.target.profile` (config/repos.json) — 명시적 override
2. `target-repo/.claude/ai-dev-loop-profile.json` — in-tree (gwangcheon-shop)
3. built-in default

`--profile`은 파일이 실제 존재할 때만 전달 — 이전엔 missing path가 분석을 죽였음.

## Test plan
- [x] `pytest` — 85/85 통과 (75 prior + 8 schema + 2 benchmark)
- [x] YAML syntax — `python3 -c \"import yaml; yaml.safe_load(...)\"`
- [x] jq 필터 5개 케이스 (daily/weekly/explicit target/non-existent/post_issues only) 로컬 검증
- [ ] 머지 후 첫 cron이 `vuejs/core`/`vercel/next.js`에 이슈를 만들지 않는지 확인 ← 가장 중요
- [ ] PR-merged dispatch (gwangcheon-shop에서 PR 머지) 시 매트릭스에 그 레포 1개만 잡히는지 확인
- [ ] `workflow_dispatch`로 dry-run 1회 (각 레포 개별 + 전체 둘 다)

## Out of scope
- analyze.py incremental fetch (별도 PR — `fetch_limit` 200 이상으로 키우려면 필수)
- 외부 레포 클러스터 → gwangcheon-shop daily report 통합
- PAT 시크릿 분리 (cross-repo 읽기 전용 PAT)
- gwangcheon-shop notify-ai-analyzer.yml 에 `client_payload.repo` 추가 (현재는 fallback으로 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)