### PR TITLE
fix(workflow): repo_slug SSoT + analyze.py --since incremental fetch

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -106,8 +106,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh label create "daily-report" --color "e4e669" --description "Daily auto-analysis report" 2>/dev/null || true
-          # 레포별 데이터 디렉토리 (멀티 레포 지원 — slug: owner_repo)
-          REPO_SLUG=$(echo "$TARGET_REPO" | tr '/' '_')
+          # repo_store.repo_slug() 단일 진실 공급원 — workflow가 직접 tr '/' '_'로
+          # 만들면 '__' (double underscore)와 미스매치돼 cache가 영영 안 커밋됨.
+          REPO_SLUG=$(python3 -c "import sys; sys.path.insert(0, 'src'); from repo_store import repo_slug; print(repo_slug('$TARGET_REPO'))")
+          echo "REPO_SLUG=$REPO_SLUG" >> $GITHUB_ENV
           mkdir -p "data/repos/${REPO_SLUG}"
           touch data/rules-history.json
 
@@ -150,9 +152,35 @@ jobs:
             echo "profile: built-in default"
           fi
 
+          # Incremental fetch: cache가 있으면 generated_at - 14일부터만 가져온다.
+          # 14일 overlap = detect_clusters의 window=14일을 보존하기 위한 최소값
+          # + 늦은 머지/리뷰/타임존 안전판. 중복 PR은 dict-based dedup으로 무해.
+          # 첫 실행 (cache 없음)이면 그냥 fetch_limit만큼.
+          SEARCH_FLAG=""
+          CACHE_PATH="data/repos/${REPO_SLUG}/analysis-cache.json"
+          if [ -f "$CACHE_PATH" ]; then
+            SINCE=$(python3 -c "
+          import json
+          from datetime import datetime, timedelta
+          try:
+              c = json.load(open('$CACHE_PATH'))
+              d = datetime.strptime(c.get('generated_at', ''), '%Y-%m-%d') - timedelta(days=14)
+              print(d.strftime('%Y-%m-%d'))
+          except Exception:
+              pass
+          ")
+            if [ -n "$SINCE" ]; then
+              SEARCH_FLAG="--search merged:>=$SINCE"
+              echo "incremental fetch since $SINCE (cache generated_at - 14d, covers cluster window)"
+            fi
+          else
+            echo "first run for $TARGET_REPO — fetching latest $LIMIT PRs"
+          fi
+
           gh pr list \
             --repo "$TARGET_REPO" \
             --state merged --limit $LIMIT \
+            $SEARCH_FLAG \
             --json number,title,mergedAt,additions,deletions \
             > /tmp/prs.json
 
@@ -569,7 +597,7 @@ jobs:
           set -e
           git config user.name "ai-dev-loop-analyzer[bot]"
           git config user.email "ai-dev-loop-analyzer@users.noreply.github.com"
-          REPO_SLUG=$(echo "$TARGET_REPO" | tr '/' '_')
+          # REPO_SLUG는 Step 0에서 GITHUB_ENV로 export됨 — 여기서 재계산하면 동기 깨짐.
           git add data/rules-history.json data/diff-patterns.json || true
           git add "data/repos/${REPO_SLUG}/" || true
           if git diff --staged --quiet; then

--- a/data/repos/rladmsgh34__gwangcheon-shop/analysis-cache.json
+++ b/data/repos/rladmsgh34__gwangcheon-shop/analysis-cache.json
@@ -1,0 +1,103 @@
+{
+  "generated_at": "2026-04-26",
+  "repo": "rladmsgh34/gwangcheon-shop",
+  "fix_rate": 16.9,
+  "summary": {
+    "total_prs": 178,
+    "fix_prs": 30,
+    "fix_rate": 16.9
+  },
+  "risky_files": [
+    {
+      "file": "src/cli.py",
+      "fix_count": 1,
+      "domain": "general",
+      "last_fix_title": "fix: GCS 공개 액세스 없이 Signed URL로 이미지 처리",
+      "last_diff_snippet": "diff --git a/src/cli.py b/src/cli.py\nnew file mode 100644\nindex 0000000..2bfa25a\n--- /dev/null\n+++ b/src/cli.py\n@@ -0,0 +1,113 @@\n+#!/usr/bin/env python3\n+\"\"\"\n+ai-dev-loop-analyzer CLI 래퍼 — Claude Code PreToolUse 훅용\n+\n+사용법:\n+  # Claude Code 훅에서 stdin으로 tool 정보를 수신\n+  echo '{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/path/to/file\"}}' | python3 cli.py\n+\n+  # 단독 테스트\n+  python3 cli.py /path/to/fil"
+    },
+    {
+      "file": "src/analyze.py",
+      "fix_count": 1,
+      "domain": "general",
+      "last_fix_title": "fix: remove duplicate pnpm version from CI workflow",
+      "last_diff_snippet": "diff --git a/src/analyze.py b/src/analyze.py\nindex 371fa9e..06b9bed 100644\n--- a/src/analyze.py\n+++ b/src/analyze.py\n@@ -11,6 +11,7 @@\n import re\n import sys\n import subprocess\n+from datetime import datetime, timezone, timedelta\n import urllib.request\n import urllib.error\n from collections import Counter, defaultdict\n@@ -258,39 +259,63 @@ def fetch_ai_flags(pr_numbers: list[int]) -> dict[int, bool"
+    },
+    {
+      "file": "tests/test_analyze.py",
+      "fix_count": 1,
+      "domain": "general",
+      "last_fix_title": "fix: remove duplicate pnpm version from CI workflow",
+      "last_diff_snippet": "diff --git a/src/analyze.py b/src/analyze.py\nindex 371fa9e..06b9bed 100644\n--- a/src/analyze.py\n+++ b/src/analyze.py\n@@ -11,6 +11,7 @@\n import re\n import sys\n import subprocess\n+from datetime import datetime, timezone, timedelta\n import urllib.request\n import urllib.error\n from collections import Counter, defaultdict\n@@ -258,39 +259,63 @@ def fetch_ai_flags(pr_numbers: list[int]) -> dict[int, bool"
+    },
+    {
+      "file": "src/rag_hook.py",
+      "fix_count": 1,
+      "domain": "general",
+      "last_fix_title": "fix: sync products page category filter with URL param",
+      "last_diff_snippet": "diff --git a/src/rag_hook.py b/src/rag_hook.py\nnew file mode 100644\nindex 0000000..b140fc5\n--- /dev/null\n+++ b/src/rag_hook.py\n@@ -0,0 +1,109 @@\n+#!/usr/bin/env python3\n+\"\"\"\n+PostToolUse 훅 — 방금 작성한 코드가 과거 회귀 패턴과 유사하면 즉시 경고.\n+\n+Claude Code PostToolUse 이벤트로 stdin에서 JSON을 받아 처리한다:\n+  {\"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"...\", \"old_string\": \"...\", \"new_string\": \"...\"}}\n+\n+BM25 pickle 캐시("
+    },
+    {
+      "file": "tests/test_rag_hook.py",
+      "fix_count": 1,
+      "domain": "general",
+      "last_fix_title": "fix: sync products page category filter with URL param",
+      "last_diff_snippet": "diff --git a/src/rag_hook.py b/src/rag_hook.py\nnew file mode 100644\nindex 0000000..b140fc5\n--- /dev/null\n+++ b/src/rag_hook.py\n@@ -0,0 +1,109 @@\n+#!/usr/bin/env python3\n+\"\"\"\n+PostToolUse 훅 — 방금 작성한 코드가 과거 회귀 패턴과 유사하면 즉시 경고.\n+\n+Claude Code PostToolUse 이벤트로 stdin에서 JSON을 받아 처리한다:\n+  {\"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"...\", \"old_string\": \"...\", \"new_string\": \"...\"}}\n+\n+BM25 pickle 캐시("
+    }
+  ],
+  "domain_counts": [
+    {
+      "domain": "ci/cd",
+      "fix_count": 12
+    },
+    {
+      "domain": "general",
+      "fix_count": 4
+    },
+    {
+      "domain": "external-api",
+      "fix_count": 3
+    },
+    {
+      "domain": "security",
+      "fix_count": 3
+    },
+    {
+      "domain": "payment",
+      "fix_count": 3
+    },
+    {
+      "domain": "database",
+      "fix_count": 2
+    },
+    {
+      "domain": "test/e2e",
+      "fix_count": 2
+    },
+    {
+      "domain": "auth",
+      "fix_count": 1
+    }
+  ],
+  "ai_weak_domains": [
+    {
+      "domain": "external-api",
+      "count": 1
+    },
+    {
+      "domain": "ci/cd",
+      "count": 1
+    },
+    {
+      "domain": "general",
+      "count": 1
+    }
+  ],
+  "clusters": [
+    {
+      "start": 21,
+      "end": 321,
+      "size": 30,
+      "domain": "ci/cd"
+    }
+  ]
+}

--- a/data/repos/vercel__next.js/analysis-cache.json
+++ b/data/repos/vercel__next.js/analysis-cache.json
@@ -1,0 +1,64 @@
+{
+  "generated_at": "2026-04-26",
+  "repo": "vercel/next.js",
+  "fix_rate": 17.5,
+  "summary": {
+    "total_prs": 200,
+    "fix_prs": 35,
+    "fix_rate": 17.5
+  },
+  "risky_files": [],
+  "domain_counts": [
+    {
+      "domain": "general",
+      "fix_count": 25
+    },
+    {
+      "domain": "monorepo",
+      "fix_count": 2
+    },
+    {
+      "domain": "ci/cd",
+      "fix_count": 2
+    },
+    {
+      "domain": "font",
+      "fix_count": 1
+    },
+    {
+      "domain": "cache",
+      "fix_count": 1
+    },
+    {
+      "domain": "maintenance",
+      "fix_count": 1
+    },
+    {
+      "domain": "scripts",
+      "fix_count": 1
+    },
+    {
+      "domain": "cli",
+      "fix_count": 1
+    },
+    {
+      "domain": "test/e2e",
+      "fix_count": 1
+    }
+  ],
+  "ai_weak_domains": [],
+  "clusters": [
+    {
+      "start": 92494,
+      "end": 93113,
+      "size": 32,
+      "domain": "general"
+    },
+    {
+      "start": 93128,
+      "end": 93225,
+      "size": 3,
+      "domain": "general"
+    }
+  ]
+}

--- a/data/repos/vuejs__core/analysis-cache.json
+++ b/data/repos/vuejs__core/analysis-cache.json
@@ -1,0 +1,98 @@
+{
+  "generated_at": "2026-04-26",
+  "repo": "vuejs/core",
+  "fix_rate": 58.5,
+  "summary": {
+    "total_prs": 200,
+    "fix_prs": 117,
+    "fix_rate": 58.5
+  },
+  "risky_files": [],
+  "domain_counts": [
+    {
+      "domain": "vapor",
+      "fix_count": 44
+    },
+    {
+      "domain": "general",
+      "fix_count": 25
+    },
+    {
+      "domain": "compiler",
+      "fix_count": 19
+    },
+    {
+      "domain": "runtime",
+      "fix_count": 7
+    },
+    {
+      "domain": "hydration",
+      "fix_count": 6
+    },
+    {
+      "domain": "types",
+      "fix_count": 4
+    },
+    {
+      "domain": "reactivity",
+      "fix_count": 3
+    },
+    {
+      "domain": "maintenance",
+      "fix_count": 2
+    },
+    {
+      "domain": "ssr",
+      "fix_count": 2
+    },
+    {
+      "domain": "hmr",
+      "fix_count": 2
+    },
+    {
+      "domain": "playground",
+      "fix_count": 1
+    },
+    {
+      "domain": "docs",
+      "fix_count": 1
+    },
+    {
+      "domain": "runtime-dom",
+      "fix_count": 1
+    }
+  ],
+  "ai_weak_domains": [],
+  "clusters": [
+    {
+      "start": 14374,
+      "end": 14447,
+      "size": 17,
+      "domain": "general"
+    },
+    {
+      "start": 14443,
+      "end": 14547,
+      "size": 33,
+      "domain": "vapor"
+    },
+    {
+      "start": 14493,
+      "end": 14632,
+      "size": 36,
+      "domain": "compiler"
+    },
+    {
+      "start": 14633,
+      "end": 14709,
+      "size": 15,
+      "domain": "vapor"
+    },
+    {
+      "start": 14702,
+      "end": 14754,
+      "size": 16,
+      "domain": "vapor"
+    }
+  ]
+}

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -46,6 +46,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -95,6 +107,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -144,6 +168,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -193,6 +229,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -242,6 +290,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -279,6 +339,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -316,6 +388,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -353,6 +437,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -390,6 +486,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -427,6 +535,18 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ]
     },
@@ -447,7 +567,20 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ]
     },
     {
       "id": "7a741814",
@@ -466,7 +599,20 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ]
     },
     {
       "id": "af1a86d6",
@@ -485,7 +631,20 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ]
     },
     {
       "id": "ca8aa38f",
@@ -504,7 +663,20 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ]
     },
     {
       "id": "ab744e04",
@@ -523,22 +695,124 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ]
+    },
+    {
+      "id": "22c72089",
+      "rule": "- GCS와 외부 도메인에 대한 CSP 설정 시, 예외 처리 범위를 명확히 하고, 잘못된 접근을 방지하기 위해 특정 도메인만 허용하도록 설정할 것.",
+      "domain": "security",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "6528b6b6",
+      "rule": "- CI 구성 파일(예: GitHub Actions, Prerequisites)에서 중복된 패키지 버전 선언을 피하도록 하여 일관성을 유지할 것.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "468952ae",
+      "rule": "- 제품 페이지의 카테고리 필터와 URL 매개변수를 동기화할 때, 클라이언트와 서버 간의 데이터 일관성을 꼼꼼히 점검할 것.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "fa3254a5",
+      "rule": "- bm25 점수 기준을 만족하지 않는 이전 코드 변경 이력을 자동으로 경고하도록 PostToolUse 훅을 강화하여 회귀 검사를 수행할 것.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "01bce2f5",
+      "rule": "- 분석 과정에서 발생할 수 있는 위험 파일(예: src/cli.py, src/analyze.py 등)을 정기적으로 검토 및 업데이트하여 회귀 위험을 사전에 차단할 것.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
       "snapshots": []
     }
   ],
   "snapshots": [
     {
       "date": "2026-04-26",
-      "total_fix_rate": 17.5,
-      "general": 12.5,
-      "monorepo": 1.0,
-      "ci/cd": 1.0,
-      "font": 0.5,
-      "cache": 0.5,
-      "maintenance": 0.5,
-      "scripts": 0.5,
-      "cli": 0.5,
-      "test/e2e": 0.5
+      "total_fix_rate": 16.9,
+      "ci/cd": 6.7,
+      "general": 2.2,
+      "external-api": 1.7,
+      "security": 1.7,
+      "payment": 1.7,
+      "database": 1.1,
+      "test/e2e": 1.1,
+      "auth": 0.6
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -75,6 +75,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -153,6 +166,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -231,6 +257,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -309,6 +348,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -387,6 +439,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -453,6 +518,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -519,6 +597,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -585,6 +676,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -651,6 +755,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -717,6 +834,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -766,6 +896,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -815,6 +958,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -864,6 +1020,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -913,6 +1082,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -962,6 +1144,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -998,6 +1193,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -1034,6 +1242,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -1070,6 +1291,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -1106,6 +1340,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -1142,6 +1389,19 @@
           "playground": 0.5,
           "docs": 0.5,
           "runtime-dom": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
         }
       ]
     },
@@ -1166,7 +1426,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "b9010ee4",
@@ -1189,7 +1463,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "f7d1be71",
@@ -1212,7 +1500,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "be663e4b",
@@ -1235,7 +1537,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
     },
     {
       "id": "1314b8f2",
@@ -1258,26 +1574,131 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 17.5,
+          "general": 12.5,
+          "monorepo": 1.0,
+          "ci/cd": 1.0,
+          "font": 0.5,
+          "cache": 0.5,
+          "maintenance": 0.5,
+          "scripts": 0.5,
+          "cli": 0.5,
+          "test/e2e": 0.5
+        }
+      ]
+    },
+    {
+      "id": "fb2400a4",
+      "rule": "- \"engine.pnpm\" 필드를 수정할 때는 CI 설정과의 충돌을 확인하여 변경사항이 전체 빌드 프로세스에 미치는 영향을 검토해야 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "03c1dc50",
+      "rule": "- \"images.maximumResponseBody\" 설정을 수정할 경우, 로컬 이미지에도 적용되는지 반드시 테스트하여 예외가 발생하지 않도록 확인해야 한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "ed5a0585",
+      "rule": "- \"next/error\"에서 기본 export에 대한 주석을 과도하게 포괄적으로 처리하지 말고, 특정 페이지와 관련된 사항만 주석 처리해야 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "3ae8de2b",
+      "rule": "- swc 플러그인 관련 설정 변경 시, 상대 경로에서 문제를 일으키지 않도록 경로 유효성을 검토하고 테스트를 진행해야 한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "38847995",
+      "rule": "- prefetch 관련 설정을 변경할 때는 revalidation 중 데이터 로딩 여부에 따른 문제 발생 가능성을 항상 고려해야 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 17.5,
+        "general": 12.5,
+        "monorepo": 1.0,
+        "ci/cd": 1.0,
+        "font": 0.5,
+        "cache": 0.5,
+        "maintenance": 0.5,
+        "scripts": 0.5,
+        "cli": 0.5,
+        "test/e2e": 0.5
+      },
       "snapshots": []
     }
   ],
   "snapshots": [
     {
       "date": "2026-04-26",
-      "total_fix_rate": 58.5,
-      "vapor": 22.0,
+      "total_fix_rate": 17.5,
       "general": 12.5,
-      "compiler": 9.5,
-      "runtime": 3.5,
-      "hydration": 3.0,
-      "types": 2.0,
-      "reactivity": 1.5,
-      "maintenance": 1.0,
-      "ssr": 1.0,
-      "hmr": 1.0,
-      "playground": 0.5,
-      "docs": 0.5,
-      "runtime-dom": 0.5
+      "monorepo": 1.0,
+      "ci/cd": 1.0,
+      "font": 0.5,
+      "cache": 0.5,
+      "maintenance": 0.5,
+      "scripts": 0.5,
+      "cli": 0.5,
+      "test/e2e": 0.5
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -58,6 +58,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -119,6 +136,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -180,6 +214,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -241,6 +292,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -302,6 +370,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -351,6 +436,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -400,6 +502,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -449,6 +568,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -498,6 +634,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -547,6 +700,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -579,6 +749,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -611,6 +798,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -643,6 +847,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -675,6 +896,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -707,6 +945,23 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
         }
       ]
     },
@@ -726,7 +981,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "6528b6b6",
@@ -744,7 +1017,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "468952ae",
@@ -762,7 +1053,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "fa3254a5",
@@ -780,7 +1089,25 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": []
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
     },
     {
       "id": "01bce2f5",
@@ -798,21 +1125,159 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "total": 58.5,
+          "vapor": 22.0,
+          "general": 12.5,
+          "compiler": 9.5,
+          "runtime": 3.5,
+          "hydration": 3.0,
+          "types": 2.0,
+          "reactivity": 1.5,
+          "maintenance": 1.0,
+          "ssr": 1.0,
+          "hmr": 1.0,
+          "playground": 0.5,
+          "docs": 0.5,
+          "runtime-dom": 0.5
+        }
+      ]
+    },
+    {
+      "id": "b32ac3c9",
+      "rule": "- PR 제출 시 `vapor`, `compiler` 관련 수정이 집중되는 파일 또는 함수에는 추가적인 코드 리뷰를 수행해야 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "b9010ee4",
+      "rule": "- `teleport`, `transition` 관련 코드를 수정할 때는 이전 PR에서 발생한 논란이나 버그를 반드시 검토하여 동일한 실수를 반복하지 않도록 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "f7d1be71",
+      "rule": "- 동적 컴포넌트 처리 시 `vdom`과의 호환성을 항상 확인하고, 관련 테스트 케이스를 추가한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "be663e4b",
+      "rule": "- `ref` 사용 시, `templateRef` 키를 업데이트하는 과정에서 이전 코드의 변화를 주의 깊게 살펴보아야 한다.",
+      "domain": "general",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
+      "snapshots": []
+    },
+    {
+      "id": "1314b8f2",
+      "rule": "- 클래스와 스타일 바인딩을 변경할 때, SVG 요소에 대한 처리를 누락하지 않도록 주의하며 관련 테스트를 수행한다.",
+      "domain": "test/e2e",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 58.5,
+        "vapor": 22.0,
+        "general": 12.5,
+        "compiler": 9.5,
+        "runtime": 3.5,
+        "hydration": 3.0,
+        "types": 2.0,
+        "reactivity": 1.5,
+        "maintenance": 1.0,
+        "ssr": 1.0,
+        "hmr": 1.0,
+        "playground": 0.5,
+        "docs": 0.5,
+        "runtime-dom": 0.5
+      },
       "snapshots": []
     }
   ],
   "snapshots": [
     {
       "date": "2026-04-26",
-      "total_fix_rate": 16.9,
-      "ci/cd": 6.7,
-      "general": 2.2,
-      "external-api": 1.7,
-      "security": 1.7,
-      "payment": 1.7,
-      "database": 1.1,
-      "test/e2e": 1.1,
-      "auth": 0.6
+      "total_fix_rate": 58.5,
+      "vapor": 22.0,
+      "general": 12.5,
+      "compiler": 9.5,
+      "runtime": 3.5,
+      "hydration": 3.0,
+      "types": 2.0,
+      "reactivity": 1.5,
+      "maintenance": 1.0,
+      "ssr": 1.0,
+      "hmr": 1.0,
+      "playground": 0.5,
+      "docs": 0.5,
+      "runtime-dom": 0.5
     }
   ]
 }

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -158,12 +158,15 @@ class Cluster:
 
 
 # ── GitHub 데이터 수집 ───────────────────────────────────────────────────────
-def fetch_prs(limit: int = 300) -> list[PR]:
-    result = subprocess.run(
-        ["gh", "pr", "list", "--state", "merged", f"--limit={limit}",
-         "--json", "number,title,mergedAt,additions,deletions"],
-        capture_output=True, text=True
-    )
+def fetch_prs(limit: int = 300, since: str | None = None) -> list[PR]:
+    """
+    since: ISO date (YYYY-MM-DD). gh search filter `merged:>=DATE`로 변환.
+    """
+    cmd = ["gh", "pr", "list", "--state", "merged", f"--limit={limit}",
+           "--json", "number,title,mergedAt,additions,deletions"]
+    if since:
+        cmd.extend(["--search", f"merged:>={since}"])
+    result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"[error] gh pr list 실패: {result.stderr}", file=sys.stderr)
         sys.exit(1)
@@ -745,6 +748,9 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description="AI Dev Loop Analyzer")
     parser.add_argument("--limit", type=int, default=300, help="분석할 PR 수 (기본 300)")
+    parser.add_argument("--since", default=None,
+                        help="이 날짜(YYYY-MM-DD) 이후 머지된 PR만 fetch. gh CLI search로 위임. "
+                             "--input 사용 시에는 무시.")
     parser.add_argument("--fetch-files", action="store_true",
                         help="모든 fix PR의 파일·리뷰·diff 수집 (정밀 분석, 느림)")
     parser.add_argument("--no-smart-fetch", action="store_true",
@@ -831,7 +837,7 @@ def main():
         prs = sorted(prs, key=lambda p: p.number)
     else:
         print("PR 데이터 수집 중...", file=sys.stderr)
-        prs = fetch_prs(args.limit)
+        prs = fetch_prs(args.limit, since=args.since)
 
     pr_map_by_num = {p.number: p for p in prs}
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -494,3 +494,42 @@ def test_is_fix_case_insensitive():
     assert _is_fix("FIX: broken button") is True
     assert _is_fix("Fix the bug") is True
     assert _is_fix("PATCH: server route") is True
+
+
+# ── fetch_prs --since flag ───────────────────────────────────────────────────
+
+def test_fetch_prs_command_without_since(monkeypatch):
+    """기본 fetch_prs는 --search 플래그를 추가하지 않는다."""
+    from unittest.mock import MagicMock
+    import analyze
+
+    captured = {}
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = "[]"
+        return m
+    monkeypatch.setattr(analyze.subprocess, "run", fake_run)
+    analyze.fetch_prs(limit=50)
+    assert "--search" not in captured["cmd"]
+    assert "--limit=50" in captured["cmd"]
+
+
+def test_fetch_prs_command_with_since(monkeypatch):
+    """--since 전달 시 gh search filter `merged:>=DATE`로 변환된다."""
+    from unittest.mock import MagicMock
+    import analyze
+
+    captured = {}
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = "[]"
+        return m
+    monkeypatch.setattr(analyze.subprocess, "run", fake_run)
+    analyze.fetch_prs(limit=50, since="2026-04-01")
+    assert "--search" in captured["cmd"]
+    idx = captured["cmd"].index("--search")
+    assert captured["cmd"][idx + 1] == "merged:>=2026-04-01"


### PR DESCRIPTION
## Summary
정찰에서 드러난 결합된 두 버그를 단일 PR로 해결:

### 1. REPO_SLUG 미스매치 — silent data loss
- workflow의 `tr '/' '_'`는 single underscore, `src/repo_store.repo_slug()`는 `__` (double underscore)
- 결과: analyze.py는 `data/repos/owner__repo/analysis-cache.json`에 쓰는데 `git add data/repos/owner_repo/`는 매칭 실패 → main에 cache 0건
- PR #27/#28의 "멀티 레포 데이터 격리"가 사실상 git 커밋 측면에서는 no-op이었음
- **fix**: workflow에서 `repo_store.repo_slug()` 직접 호출 + `GITHUB_ENV`로 export

### 2. analyze.py incremental fetch via gh search
- `fetch_prs(since=...)` — `--search "merged:>=DATE"` gh CLI에 주입. since 없으면 no-op.
- `--since` CLI 플래그
- workflow Step 1: cache `generated_at` - 14일 (`detect_clusters` window 14일 + overlap) 자동 계산
- 첫 실행 (cache 없음): 기존 동작 유지

## 기대 효과
| 레포 | 기존 | incremental 후 |
|---|---|---|
| gwangcheon-shop daily | 300 PR fetch | ~5 PR fetch |
| vuejs/core weekly | 200 PR fetch | ~20-50 PR fetch |
| vercel/next.js weekly | 200 PR fetch | ~20-50 PR fetch |

API 호출 약 90% 감소. GH_PAT 5000/hr 한도에서 영구 안전.

## Test plan
- [x] `pytest` — 87/87 통과 (85 prior + 2 new fetch_prs 테스트)
- [x] YAML syntax
- [x] SINCE 계산 heredoc 로컬 검증 (cache 있음/없음 양쪽)
- [ ] 머지 후 첫 cron — `data/repos/owner__repo/analysis-cache.json`이 진짜로 main에 커밋되는지 확인 (가장 중요)
- [ ] 그 다음 cron — `--search merged:>=DATE` 로그가 찍히는지 확인

## Out of scope (별도 PR)
- File-level PR cache (이미 fetch한 PR의 `gh pr view --files` 스킵). `build_cache_dict` 스키마 확장 + 마이그레이션 동반.

🤖 Generated with [Claude Code](https://claude.com/claude-code)