### PR TITLE
feat(rule-tracker): per-repo origin tagging + cross-repo pollution guard

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -483,6 +483,11 @@ jobs:
 
           d = json.load(open('/tmp/report.json'))
           date = os.environ.get('REPORT_DATE', '')
+          target_repo = os.environ.get('TARGET_REPO', '')
+          # analyzer 본인 분석 시 self 태그 — workflow 매트릭스에서는 절대 발생 안 하지만
+          # 로컬 self-analysis 진입점 보호용. (workflow는 항상 외부 repo 분석)
+          analyzer_repo = 'rladmsgh34/ai-dev-loop-analyzer'
+          origin = 'self' if target_repo == analyzer_repo else target_repo
           total_fix = d['summary']['fix_rate']
           total_prs = d['summary']['total_prs']
 
@@ -492,18 +497,21 @@ jobs:
               if total_prs > 0:
                   domain_rates[dc['domain']] = round(dc['fix_count'] / total_prs * 100, 1)
 
-          # 1) 스냅샷 기록
-          record_snapshot(domain_rates, total_fix, date)
-          print(f"스냅샷 기록 완료: {date}")
+          # 1) 스냅샷 기록 — repo 태그로 cross-repo pollution 차단
+          record_snapshot(domain_rates, total_fix, date, repo=origin)
+          print(f"스냅샷 기록 완료: {date} [{origin}]")
 
           # 2) 오늘 제안된 규칙을 히스토리에 등록 (추가 시점 fix-rate 기준점 저장)
+          # 새 rule은 항상 explicit fact (분석 시점에 어느 repo 분석 중인지 확실).
           rules = d.get('claude_md_suggestions', [])
           if rules:
-              added = record_new_rules(rules, domain_rates, total_fix, date)
-              print(f"신규 규칙 등록: {len(added)}개")
+              added = record_new_rules(rules, domain_rates, total_fix, date,
+                                        repo=origin, origin_confidence='explicit')
+              print(f"신규 규칙 등록: {len(added)}개 [origin={origin}]")
           PYEOF
         env:
           REPORT_DATE: ${{ steps.analyze.outputs.date }}
+          TARGET_REPO: ${{ env.TARGET_REPO }}
 
       # ── 3.5단계: diff 패턴 누적 저장 (RAG 임베딩용) ────────────────────────
       - name: diff 패턴 저장

--- a/data/repos/vercel__next.js/analysis-cache.json
+++ b/data/repos/vercel__next.js/analysis-cache.json
@@ -1,29 +1,17 @@
 {
   "generated_at": "2026-04-26",
   "repo": "vercel/next.js",
-  "fix_rate": 17.5,
+  "fix_rate": 13.1,
   "summary": {
-    "total_prs": 200,
-    "fix_prs": 35,
-    "fix_rate": 17.5
+    "total_prs": 168,
+    "fix_prs": 22,
+    "fix_rate": 13.1
   },
   "risky_files": [],
   "domain_counts": [
     {
       "domain": "general",
-      "fix_count": 25
-    },
-    {
-      "domain": "monorepo",
-      "fix_count": 2
-    },
-    {
-      "domain": "ci/cd",
-      "fix_count": 2
-    },
-    {
-      "domain": "font",
-      "fix_count": 1
+      "fix_count": 16
     },
     {
       "domain": "cache",
@@ -35,6 +23,10 @@
     },
     {
       "domain": "scripts",
+      "fix_count": 1
+    },
+    {
+      "domain": "monorepo",
       "fix_count": 1
     },
     {
@@ -50,14 +42,8 @@
   "clusters": [
     {
       "start": 92494,
-      "end": 93113,
-      "size": 32,
-      "domain": "general"
-    },
-    {
-      "start": 93128,
       "end": 93225,
-      "size": 3,
+      "size": 22,
       "domain": "general"
     }
   ]

--- a/data/repos/vuejs__core/analysis-cache.json
+++ b/data/repos/vuejs__core/analysis-cache.json
@@ -1,60 +1,32 @@
 {
   "generated_at": "2026-04-26",
   "repo": "vuejs/core",
-  "fix_rate": 58.5,
+  "fix_rate": 63.0,
   "summary": {
-    "total_prs": 200,
-    "fix_prs": 117,
-    "fix_rate": 58.5
+    "total_prs": 27,
+    "fix_prs": 17,
+    "fix_rate": 63.0
   },
   "risky_files": [],
   "domain_counts": [
     {
       "domain": "vapor",
-      "fix_count": 44
-    },
-    {
-      "domain": "general",
-      "fix_count": 25
-    },
-    {
-      "domain": "compiler",
-      "fix_count": 19
-    },
-    {
-      "domain": "runtime",
       "fix_count": 7
     },
     {
-      "domain": "hydration",
-      "fix_count": 6
-    },
-    {
-      "domain": "types",
+      "domain": "general",
       "fix_count": 4
     },
     {
-      "domain": "reactivity",
+      "domain": "compiler",
       "fix_count": 3
     },
     {
-      "domain": "maintenance",
-      "fix_count": 2
-    },
-    {
-      "domain": "ssr",
-      "fix_count": 2
-    },
-    {
-      "domain": "hmr",
-      "fix_count": 2
-    },
-    {
-      "domain": "playground",
+      "domain": "hydration",
       "fix_count": 1
     },
     {
-      "domain": "docs",
+      "domain": "reactivity",
       "fix_count": 1
     },
     {
@@ -65,33 +37,9 @@
   "ai_weak_domains": [],
   "clusters": [
     {
-      "start": 14374,
-      "end": 14447,
-      "size": 17,
-      "domain": "general"
-    },
-    {
-      "start": 14443,
-      "end": 14547,
-      "size": 33,
-      "domain": "vapor"
-    },
-    {
-      "start": 14493,
-      "end": 14632,
-      "size": 36,
-      "domain": "compiler"
-    },
-    {
-      "start": 14633,
-      "end": 14709,
-      "size": 15,
-      "domain": "vapor"
-    },
-    {
       "start": 14702,
       "end": 14754,
-      "size": 16,
+      "size": 17,
       "domain": "vapor"
     }
   ]

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -256,6 +256,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -372,6 +384,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -418,6 +442,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -464,6 +500,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -510,6 +558,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -555,6 +615,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -600,6 +672,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -645,6 +729,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -690,6 +786,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -834,6 +942,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -884,6 +1004,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -934,6 +1066,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -980,6 +1124,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1026,6 +1182,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1072,6 +1240,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1118,6 +1298,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1164,6 +1356,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1358,6 +1562,101 @@
         "runtime-dom": 3.7
       },
       "snapshots": []
+    },
+    {
+      "id": "5e784106",
+      "rule": "- PR에 `fix` 레이블이 붙은 경우, 반드시 관련된 테스트 케이스를 동반하여 변경 사항을 확인해야 한다.",
+      "domain": "test/e2e",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "f514671c",
+      "rule": "- `prefetch` 또는 `revalidation` 관련 기능을 수정할 때는 데이터 흐름과 상태 관리를 철저히 분석하여 사이드 이펙트를 최소화해야 한다.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "17f0785d",
+      "rule": "- `dev` 모드와 관련된 PR에서는 HTTP 캐시와의 호환성 문제를 해결하기 위한 추가 테스트를 구현해야 한다.",
+      "domain": "test/e2e",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "57351a0a",
+      "rule": "- `webpack` 설정 변경 시, 상대 경로 사용에 대한 검증을 반드시 포함하여 오류를 예방해야 한다.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "f0da7267",
+      "rule": "- `cache` 및 `swc`와 관련된 기능 수정 시, 해당 기능의 내부 상태와 의존성을 명확히 문서화하고 주석을 추가해야 한다.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
     }
   ],
   "snapshots": [
@@ -1384,6 +1683,18 @@
       "hydration": 3.7,
       "reactivity": 3.7,
       "runtime-dom": 3.7
+    },
+    {
+      "date": "2026-04-26",
+      "repo": "vercel/next.js",
+      "total_fix_rate": 13.1,
+      "general": 9.5,
+      "cache": 0.6,
+      "maintenance": 0.6,
+      "scripts": 0.6,
+      "monorepo": 0.6,
+      "cli": 0.6,
+      "test/e2e": 0.6
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -16,80 +16,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "self",
       "origin_confidence": "explicit"
     },
@@ -109,80 +36,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "self",
       "origin_confidence": "explicit"
     },
@@ -202,80 +56,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "self",
       "origin_confidence": "explicit"
     },
@@ -295,80 +76,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "self",
       "origin_confidence": "explicit"
     },
@@ -388,80 +96,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "self",
       "origin_confidence": "explicit"
     },
@@ -486,74 +121,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -578,74 +146,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -670,74 +171,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -762,99 +196,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -879,74 +221,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -967,61 +242,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -1042,86 +263,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1142,86 +284,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1242,86 +305,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1342,86 +326,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1441,74 +346,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1528,74 +366,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1615,74 +386,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1702,74 +406,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1789,38 +426,7 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 58.5,
-          "vapor": 22.0,
-          "general": 12.5,
-          "compiler": 9.5,
-          "runtime": 3.5,
-          "hydration": 3.0,
-          "types": 2.0,
-          "reactivity": 1.5,
-          "maintenance": 1.0,
-          "ssr": 1.0,
-          "hmr": 1.0,
-          "playground": 0.5,
-          "docs": 0.5,
-          "runtime-dom": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "self",
       "origin_confidence": "explicit"
     },
@@ -1845,32 +451,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -1895,32 +476,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -1945,57 +501,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2020,57 +526,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2095,57 +551,7 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "total": 17.5,
-          "general": 12.5,
-          "monorepo": 1.0,
-          "ci/cd": 1.0,
-          "font": 0.5,
-          "cache": 0.5,
-          "maintenance": 0.5,
-          "scripts": 0.5,
-          "cli": 0.5,
-          "test/e2e": 0.5
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2166,44 +572,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2224,44 +593,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2282,44 +614,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2340,44 +635,7 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -2398,382 +656,10 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [
-        {
-          "date": "2026-04-26",
-          "repo": "rladmsgh34/gwangcheon-shop",
-          "total": 16.9,
-          "ci/cd": 6.7,
-          "general": 2.2,
-          "external-api": 1.7,
-          "security": 1.7,
-          "payment": 1.7,
-          "database": 1.1,
-          "test/e2e": 1.1,
-          "auth": 0.6
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vuejs/core",
-          "total": 63.0,
-          "vapor": 25.9,
-          "general": 14.8,
-          "compiler": 11.1,
-          "hydration": 3.7,
-          "reactivity": 3.7,
-          "runtime-dom": 3.7
-        },
-        {
-          "date": "2026-04-26",
-          "repo": "vercel/next.js",
-          "total": 13.1,
-          "general": 9.5,
-          "cache": 0.6,
-          "maintenance": 0.6,
-          "scripts": 0.6,
-          "monorepo": 0.6,
-          "cli": 0.6,
-          "test/e2e": 0.6
-        }
-      ],
+      "snapshots": [],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
-    },
-    {
-      "id": "2c4564cf",
-      "rule": "- GCS에 대한 접근은 반드시 Signed URL을 사용하여 처리하며, 공개 액세스 없이 이미지 처리 코드를 작성해야 한다.",
-      "domain": "external-api",
-      "origin_repo": "rladmsgh34/gwangcheon-shop",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 16.9,
-        "ci/cd": 6.7,
-        "general": 2.2,
-        "external-api": 1.7,
-        "security": 1.7,
-        "payment": 1.7,
-        "database": 1.1,
-        "test/e2e": 1.1,
-        "auth": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "12651076",
-      "rule": "- CI/CD 관련 PR에서는 pnpm 버전을 중복으로 선언하지 않도록 주의하고, 모든 설정을 명확히 문서화한다.",
-      "domain": "ci/cd",
-      "origin_repo": "rladmsgh34/gwangcheon-shop",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 16.9,
-        "ci/cd": 6.7,
-        "general": 2.2,
-        "external-api": 1.7,
-        "security": 1.7,
-        "payment": 1.7,
-        "database": 1.1,
-        "test/e2e": 1.1,
-        "auth": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "62372d15",
-      "rule": "- 프로덕트 페이지의 카테고리 필터는 URL 파라미터와 항상 동기화되도록 관리해야 하며, 이를 검증하는 테스트를 추가한다.",
-      "domain": "test/e2e",
-      "origin_repo": "rladmsgh34/gwangcheon-shop",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 16.9,
-        "ci/cd": 6.7,
-        "general": 2.2,
-        "external-api": 1.7,
-        "security": 1.7,
-        "payment": 1.7,
-        "database": 1.1,
-        "test/e2e": 1.1,
-        "auth": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "02e3cbd9",
-      "rule": "- 응용 프로그램의 코드 변경 시 BM25 캐시 파일이 존재하는지 항상 확인하고, 예상치 못한 오류를 방지하기 위해 예외 처리를 철저히 한다.",
-      "domain": "general",
-      "origin_repo": "rladmsgh34/gwangcheon-shop",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 16.9,
-        "ci/cd": 6.7,
-        "general": 2.2,
-        "external-api": 1.7,
-        "security": 1.7,
-        "payment": 1.7,
-        "database": 1.1,
-        "test/e2e": 1.1,
-        "auth": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "0c8de339",
-      "rule": "- cluster detection 알고리즘에서는 mergedAt 기준으로 PR 간의 시간 차이를 14일로 설정하고, 토큰의 유사도를 기준으로 클러스터를 식별할 때 정확성을 높인다.",
-      "domain": "general",
-      "origin_repo": "rladmsgh34/gwangcheon-shop",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 16.9,
-        "ci/cd": 6.7,
-        "general": 2.2,
-        "external-api": 1.7,
-        "security": 1.7,
-        "payment": 1.7,
-        "database": 1.1,
-        "test/e2e": 1.1,
-        "auth": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "d86205f1",
-      "rule": "- PR 제출 시, `runtime-vapor` 관련 코드 수정이 포함된 경우, 반드시 관련 문서와 주석을 업데이트하여 변경 사항을 명확히 해야 한다.",
-      "domain": "general",
-      "origin_repo": "vuejs/core",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 63.0,
-        "vapor": 25.9,
-        "general": 14.8,
-        "compiler": 11.1,
-        "hydration": 3.7,
-        "reactivity": 3.7,
-        "runtime-dom": 3.7
-      },
-      "snapshots": []
-    },
-    {
-      "id": "c5ab87be",
-      "rule": "- `compiler-sfc`에서 `:deep`과 같은 선택자 관련 수정이 있을 경우, 모든 연관된 CSS 파일을 검토하여 영향을 받을 수 있는 부분을 확인하고 수정해야 한다.",
-      "domain": "general",
-      "origin_repo": "vuejs/core",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 63.0,
-        "vapor": 25.9,
-        "general": 14.8,
-        "compiler": 11.1,
-        "hydration": 3.7,
-        "reactivity": 3.7,
-        "runtime-dom": 3.7
-      },
-      "snapshots": []
-    },
-    {
-      "id": "4514da29",
-      "rule": "- PR에서 `keepalive` 및 `teleport` 관련 기능을 수정하는 경우, 해당 기능의 유닛 테스트를 반드시 포함해야 하며, 새로운 테스트 케이스를 추가하여 회귀를 방지해야 한다.",
-      "domain": "test/e2e",
-      "origin_repo": "vuejs/core",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 63.0,
-        "vapor": 25.9,
-        "general": 14.8,
-        "compiler": 11.1,
-        "hydration": 3.7,
-        "reactivity": 3.7,
-        "runtime-dom": 3.7
-      },
-      "snapshots": []
-    },
-    {
-      "id": "0ba10b7f",
-      "rule": "- `vdom` 관련 수정이 포함된 PR은 배포 전에 시각적 회귀 테스트를 수행하여 UI 변경 사항이 의도한 대로 나타나는지 확인해야 한다.",
-      "domain": "test/e2e",
-      "origin_repo": "vuejs/core",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 63.0,
-        "vapor": 25.9,
-        "general": 14.8,
-        "compiler": 11.1,
-        "hydration": 3.7,
-        "reactivity": 3.7,
-        "runtime-dom": 3.7
-      },
-      "snapshots": []
-    },
-    {
-      "id": "d24fdc6e",
-      "rule": "- `textarea`와 관련된 기능 수정이 있을 경우, 다양한 화면 크기와 환경에서의 테스트를 통해 크기 조정 기능이 정상적으로 작동하는지 검증해야 한다.",
-      "domain": "test/e2e",
-      "origin_repo": "vuejs/core",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 63.0,
-        "vapor": 25.9,
-        "general": 14.8,
-        "compiler": 11.1,
-        "hydration": 3.7,
-        "reactivity": 3.7,
-        "runtime-dom": 3.7
-      },
-      "snapshots": []
-    },
-    {
-      "id": "82fd2473",
-      "rule": "- PR 작성 시 서버 참조 등록과 관련된 `ExportNamed`의 타입만 있는 경우, 사전 패스를 건너뛰도록 주의할 것.",
-      "domain": "general",
-      "origin_repo": "vercel/next.js",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 13.1,
-        "general": 9.5,
-        "cache": 0.6,
-        "maintenance": 0.6,
-        "scripts": 0.6,
-        "monorepo": 0.6,
-        "cli": 0.6,
-        "test/e2e": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "90466d25",
-      "rule": "- 리밸리데이션 중에 prefetch 힌트가 로드되지 않는 문제를 방지하기 위해 관련 기능의 코드 검토를 철저히 할 것.",
-      "domain": "general",
-      "origin_repo": "vercel/next.js",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 13.1,
-        "general": 9.5,
-        "cache": 0.6,
-        "maintenance": 0.6,
-        "scripts": 0.6,
-        "monorepo": 0.6,
-        "cli": 0.6,
-        "test/e2e": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "19a03a24",
-      "rule": "- 에러 발생 시 셀 정리를 허용하도록 재계산 루프를 수정할 때, `turbo-tasks` 관련 함수의 에러 처리 로직을 명확히 정의할 것.",
-      "domain": "general",
-      "origin_repo": "vercel/next.js",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 13.1,
-        "general": 9.5,
-        "cache": 0.6,
-        "maintenance": 0.6,
-        "scripts": 0.6,
-        "monorepo": 0.6,
-        "cli": 0.6,
-        "test/e2e": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "a3714a28",
-      "rule": "- `next/image`의 `images.maximumResponseBody` 설정이 로컬 이미지에도 적용되도록 코드 리뷰 과정에서 관련 테스트를 상시 포함할 것.",
-      "domain": "test/e2e",
-      "origin_repo": "vercel/next.js",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 13.1,
-        "general": 9.5,
-        "cache": 0.6,
-        "maintenance": 0.6,
-        "scripts": 0.6,
-        "monorepo": 0.6,
-        "cli": 0.6,
-        "test/e2e": 0.6
-      },
-      "snapshots": []
-    },
-    {
-      "id": "2f5ae2f7",
-      "rule": "- CI 워크플로우와 관련된 PR에서는 항상 권한 및 자동 레이블링 기능의 동작 여부를 검토할 것.",
-      "domain": "general",
-      "origin_repo": "vercel/next.js",
-      "origin_confidence": "explicit",
-      "date_added": "2026-04-26",
-      "fix_rate_at_add": {
-        "total": 13.1,
-        "general": 9.5,
-        "cache": 0.6,
-        "maintenance": 0.6,
-        "scripts": 0.6,
-        "monorepo": 0.6,
-        "cli": 0.6,
-        "test/e2e": 0.6
-      },
-      "snapshots": []
     }
   ],
-  "snapshots": [
-    {
-      "date": "2026-04-26",
-      "total_fix_rate": 17.5,
-      "general": 12.5,
-      "monorepo": 1.0,
-      "ci/cd": 1.0,
-      "font": 0.5,
-      "cache": 0.5,
-      "maintenance": 0.5,
-      "scripts": 0.5,
-      "cli": 0.5,
-      "test/e2e": 0.5
-    },
-    {
-      "date": "2026-04-26",
-      "repo": "rladmsgh34/gwangcheon-shop",
-      "total_fix_rate": 16.9,
-      "ci/cd": 6.7,
-      "general": 2.2,
-      "external-api": 1.7,
-      "security": 1.7,
-      "payment": 1.7,
-      "database": 1.1,
-      "test/e2e": 1.1,
-      "auth": 0.6
-    },
-    {
-      "date": "2026-04-26",
-      "repo": "vuejs/core",
-      "total_fix_rate": 63.0,
-      "vapor": 25.9,
-      "general": 14.8,
-      "compiler": 11.1,
-      "hydration": 3.7,
-      "reactivity": 3.7,
-      "runtime-dom": 3.7
-    },
-    {
-      "date": "2026-04-26",
-      "repo": "vercel/next.js",
-      "total_fix_rate": 13.1,
-      "general": 9.5,
-      "cache": 0.6,
-      "maintenance": 0.6,
-      "scripts": 0.6,
-      "monorepo": 0.6,
-      "cli": 0.6,
-      "test/e2e": 0.6
-    }
-  ]
+  "snapshots": []
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -541,6 +541,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -622,6 +633,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -703,6 +725,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -797,6 +830,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -878,6 +922,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -942,6 +997,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -1019,6 +1085,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1096,6 +1173,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1173,6 +1261,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1250,6 +1349,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1314,6 +1424,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1378,6 +1499,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1442,6 +1574,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1506,6 +1649,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1596,6 +1750,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -1635,6 +1800,17 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "vuejs/core",
@@ -1687,6 +1863,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1739,6 +1926,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1791,6 +1989,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1826,6 +2035,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1861,6 +2081,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1896,6 +2127,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1931,6 +2173,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -1966,6 +2219,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -2070,6 +2334,96 @@
         "auth": 0.6
       },
       "snapshots": []
+    },
+    {
+      "id": "d86205f1",
+      "rule": "- PR 제출 시, `runtime-vapor` 관련 코드 수정이 포함된 경우, 반드시 관련 문서와 주석을 업데이트하여 변경 사항을 명확히 해야 한다.",
+      "domain": "general",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "c5ab87be",
+      "rule": "- `compiler-sfc`에서 `:deep`과 같은 선택자 관련 수정이 있을 경우, 모든 연관된 CSS 파일을 검토하여 영향을 받을 수 있는 부분을 확인하고 수정해야 한다.",
+      "domain": "general",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "4514da29",
+      "rule": "- PR에서 `keepalive` 및 `teleport` 관련 기능을 수정하는 경우, 해당 기능의 유닛 테스트를 반드시 포함해야 하며, 새로운 테스트 케이스를 추가하여 회귀를 방지해야 한다.",
+      "domain": "test/e2e",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "0ba10b7f",
+      "rule": "- `vdom` 관련 수정이 포함된 PR은 배포 전에 시각적 회귀 테스트를 수행하여 UI 변경 사항이 의도한 대로 나타나는지 확인해야 한다.",
+      "domain": "test/e2e",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "d24fdc6e",
+      "rule": "- `textarea`와 관련된 기능 수정이 있을 경우, 다양한 화면 크기와 환경에서의 테스트를 통해 크기 조정 기능이 정상적으로 작동하는지 검증해야 한다.",
+      "domain": "test/e2e",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
     }
   ],
   "snapshots": [
@@ -2098,6 +2452,17 @@
       "database": 1.1,
       "test/e2e": 1.1,
       "auth": 0.6
+    },
+    {
+      "date": "2026-04-26",
+      "repo": "vuejs/core",
+      "total_fix_rate": 63.0,
+      "vapor": 25.9,
+      "general": 14.8,
+      "compiler": 11.1,
+      "hydration": 3.7,
+      "reactivity": 3.7,
+      "runtime-dom": 3.7
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -89,7 +89,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "self",
+      "origin_confidence": "explicit"
     },
     {
       "id": "afe62a64",
@@ -180,7 +182,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "self",
+      "origin_confidence": "explicit"
     },
     {
       "id": "09a27d86",
@@ -271,7 +275,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "self",
+      "origin_confidence": "explicit"
     },
     {
       "id": "c6e0595d",
@@ -362,7 +368,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "self",
+      "origin_confidence": "explicit"
     },
     {
       "id": "b89b775d",
@@ -453,7 +461,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "self",
+      "origin_confidence": "explicit"
     },
     {
       "id": "32699aeb",
@@ -532,7 +542,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "a13e1029",
@@ -611,7 +623,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "8607b6a2",
@@ -690,7 +704,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "aeaaa483",
@@ -769,7 +785,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "be61b6cd",
@@ -848,7 +866,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "53a34351",
@@ -910,7 +930,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "7a741814",
@@ -972,7 +994,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "af1a86d6",
@@ -1034,7 +1058,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "ca8aa38f",
@@ -1096,7 +1122,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "ab744e04",
@@ -1158,7 +1186,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "22c72089",
@@ -1207,7 +1237,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "6528b6b6",
@@ -1256,7 +1288,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "468952ae",
@@ -1305,7 +1339,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "fa3254a5",
@@ -1354,7 +1390,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "01bce2f5",
@@ -1403,7 +1441,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "self",
+      "origin_confidence": "explicit"
     },
     {
       "id": "b32ac3c9",
@@ -1440,7 +1480,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "b9010ee4",
@@ -1477,7 +1519,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "inferred"
     },
     {
       "id": "f7d1be71",
@@ -1514,7 +1558,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "be663e4b",
@@ -1551,7 +1597,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "1314b8f2",
@@ -1588,7 +1636,9 @@
           "cli": 0.5,
           "test/e2e": 0.5
         }
-      ]
+      ],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "fb2400a4",
@@ -1607,7 +1657,9 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "03c1dc50",
@@ -1626,7 +1678,9 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "ed5a0585",
@@ -1645,7 +1699,9 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "3ae8de2b",
@@ -1664,7 +1720,9 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     },
     {
       "id": "38847995",
@@ -1683,7 +1741,9 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": []
+      "snapshots": [],
+      "origin_repo": "unknown",
+      "origin_confidence": "unknown"
     }
   ],
   "snapshots": [

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -841,6 +841,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1096,6 +1108,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1184,6 +1208,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1272,6 +1308,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1360,6 +1408,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1435,6 +1495,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1510,6 +1582,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1585,6 +1669,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1660,6 +1756,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1874,6 +1982,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1937,6 +2057,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2000,6 +2132,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2046,6 +2190,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2092,6 +2248,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2138,6 +2306,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2184,6 +2364,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2230,6 +2422,18 @@
           "hydration": 3.7,
           "reactivity": 3.7,
           "runtime-dom": 3.7
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vercel/next.js",
+          "total": 13.1,
+          "general": 9.5,
+          "cache": 0.6,
+          "maintenance": 0.6,
+          "scripts": 0.6,
+          "monorepo": 0.6,
+          "cli": 0.6,
+          "test/e2e": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -2424,6 +2628,101 @@
         "runtime-dom": 3.7
       },
       "snapshots": []
+    },
+    {
+      "id": "82fd2473",
+      "rule": "- PR 작성 시 서버 참조 등록과 관련된 `ExportNamed`의 타입만 있는 경우, 사전 패스를 건너뛰도록 주의할 것.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "90466d25",
+      "rule": "- 리밸리데이션 중에 prefetch 힌트가 로드되지 않는 문제를 방지하기 위해 관련 기능의 코드 검토를 철저히 할 것.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "19a03a24",
+      "rule": "- 에러 발생 시 셀 정리를 허용하도록 재계산 루프를 수정할 때, `turbo-tasks` 관련 함수의 에러 처리 로직을 명확히 정의할 것.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "a3714a28",
+      "rule": "- `next/image`의 `images.maximumResponseBody` 설정이 로컬 이미지에도 적용되도록 코드 리뷰 과정에서 관련 테스트를 상시 포함할 것.",
+      "domain": "test/e2e",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "2f5ae2f7",
+      "rule": "- CI 워크플로우와 관련된 PR에서는 항상 권한 및 자동 레이블링 기능의 동작 여부를 검토할 것.",
+      "domain": "general",
+      "origin_repo": "vercel/next.js",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 13.1,
+        "general": 9.5,
+        "cache": 0.6,
+        "maintenance": 0.6,
+        "scripts": 0.6,
+        "monorepo": 0.6,
+        "cli": 0.6,
+        "test/e2e": 0.6
+      },
+      "snapshots": []
     }
   ],
   "snapshots": [
@@ -2463,6 +2762,18 @@
       "hydration": 3.7,
       "reactivity": 3.7,
       "runtime-dom": 3.7
+    },
+    {
+      "date": "2026-04-26",
+      "repo": "vercel/next.js",
+      "total_fix_rate": 13.1,
+      "general": 9.5,
+      "cache": 0.6,
+      "maintenance": 0.6,
+      "scripts": 0.6,
+      "monorepo": 0.6,
+      "cli": 0.6,
+      "test/e2e": 0.6
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -784,6 +784,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -993,6 +1006,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1057,6 +1083,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1121,6 +1160,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1185,6 +1237,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1236,6 +1301,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1287,6 +1365,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1338,6 +1429,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1389,6 +1493,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1557,6 +1674,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1596,6 +1726,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1635,6 +1778,19 @@
           "scripts": 0.5,
           "cli": 0.5,
           "test/e2e": 0.5
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
         }
       ],
       "origin_repo": "unknown",
@@ -1657,7 +1813,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1678,7 +1848,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1699,7 +1883,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1720,7 +1918,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -1741,9 +1953,123 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
+    },
+    {
+      "id": "2c4564cf",
+      "rule": "- GCS에 대한 접근은 반드시 Signed URL을 사용하여 처리하며, 공개 액세스 없이 이미지 처리 코드를 작성해야 한다.",
+      "domain": "external-api",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "12651076",
+      "rule": "- CI/CD 관련 PR에서는 pnpm 버전을 중복으로 선언하지 않도록 주의하고, 모든 설정을 명확히 문서화한다.",
+      "domain": "ci/cd",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "62372d15",
+      "rule": "- 프로덕트 페이지의 카테고리 필터는 URL 파라미터와 항상 동기화되도록 관리해야 하며, 이를 검증하는 테스트를 추가한다.",
+      "domain": "test/e2e",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "02e3cbd9",
+      "rule": "- 응용 프로그램의 코드 변경 시 BM25 캐시 파일이 존재하는지 항상 확인하고, 예상치 못한 오류를 방지하기 위해 예외 처리를 철저히 한다.",
+      "domain": "general",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "0c8de339",
+      "rule": "- cluster detection 알고리즘에서는 mergedAt 기준으로 PR 간의 시간 차이를 14일로 설정하고, 토큰의 유사도를 기준으로 클러스터를 식별할 때 정확성을 높인다.",
+      "domain": "general",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
     }
   ],
   "snapshots": [
@@ -1759,6 +2085,19 @@
       "scripts": 0.5,
       "cli": 0.5,
       "test/e2e": 0.5
+    },
+    {
+      "date": "2026-04-26",
+      "repo": "rladmsgh34/gwangcheon-shop",
+      "total_fix_rate": 16.9,
+      "ci/cd": 6.7,
+      "general": 2.2,
+      "external-api": 1.7,
+      "security": 1.7,
+      "payment": 1.7,
+      "database": 1.1,
+      "test/e2e": 1.1,
+      "auth": 0.6
     }
   ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -196,7 +196,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -263,7 +277,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -284,7 +312,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -305,7 +347,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -326,7 +382,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -346,7 +416,21 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -366,7 +450,21 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -386,7 +484,21 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -406,7 +518,21 @@
         "test/e2e": 1.1,
         "auth": 0.6
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -501,7 +627,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -526,7 +666,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -551,7 +705,21 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -572,7 +740,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -593,7 +775,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -614,7 +810,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -635,7 +845,21 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
     },
@@ -656,10 +880,138 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "rladmsgh34/gwangcheon-shop",
+          "total": 16.9,
+          "ci/cd": 6.7,
+          "general": 2.2,
+          "external-api": 1.7,
+          "security": 1.7,
+          "payment": 1.7,
+          "database": 1.1,
+          "test/e2e": 1.1,
+          "auth": 0.6
+        }
+      ],
       "origin_repo": "unknown",
       "origin_confidence": "unknown"
+    },
+    {
+      "id": "7b4a573f",
+      "rule": "- GCS에 대한 Signed URL 처리 시, 공개 액세스를 비활성화하고 항상 안전한 URL 생성 방법을 사용하십시오. (파일: src/cli.py)",
+      "domain": "external-api",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "93a8befd",
+      "rule": "- CI 워크플로우의 pnpm 버전 설정은 중복되지 않도록 유지하고, 여러 파일에서 일관되게 설정하십시오. (파일: src/analyze.py)",
+      "domain": "general",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "8ed3a8a6",
+      "rule": "- 제품 페이지의 카테고리 필터와 URL 파라미터 간의 동기화를 철저히 검사하고, 변경 시 반드시 기능 테스트를 수행하십시오. (파일: src/rag_hook.py)",
+      "domain": "test/e2e",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "b9436336",
+      "rule": "- CI/CD 관련 PR은 특히 보안 및 권한 설정에 주의를 기울이고, 레거시 코드와의 호환성을 지속적으로 확인하십시오. (PR 범위: #21~#321)",
+      "domain": "ci/cd",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
+    },
+    {
+      "id": "d8dc713d",
+      "rule": "- XSS 방어를 위한 RichText HTML 저장 및 렌더링 과정에서 모든 사용자 입력을 철저히 검증하고 필터링하십시오. (실행 파일: src/rag_hook.py)",
+      "domain": "security",
+      "origin_repo": "rladmsgh34/gwangcheon-shop",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 16.9,
+        "ci/cd": 6.7,
+        "general": 2.2,
+        "external-api": 1.7,
+        "security": 1.7,
+        "payment": 1.7,
+        "database": 1.1,
+        "test/e2e": 1.1,
+        "auth": 0.6
+      },
+      "snapshots": []
     }
   ],
-  "snapshots": []
+  "snapshots": [
+    {
+      "date": "2026-04-26",
+      "repo": "rladmsgh34/gwangcheon-shop",
+      "total_fix_rate": 16.9,
+      "ci/cd": 6.7,
+      "general": 2.2,
+      "external-api": 1.7,
+      "security": 1.7,
+      "payment": 1.7,
+      "database": 1.1,
+      "test/e2e": 1.1,
+      "auth": 0.6
+    }
+  ]
 }

--- a/data/rules-history.json
+++ b/data/rules-history.json
@@ -121,7 +121,19 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -146,7 +158,19 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -171,7 +195,19 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -209,6 +245,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -235,7 +282,19 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -256,7 +315,19 @@
         "cli": 0.5,
         "test/e2e": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -290,6 +361,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -325,6 +407,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -360,6 +453,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -395,6 +499,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -429,6 +544,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -463,6 +589,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -497,6 +634,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -531,6 +679,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -577,7 +736,19 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -602,7 +773,19 @@
         "docs": 0.5,
         "runtime-dom": 0.5
       },
-      "snapshots": [],
+      "snapshots": [
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
+        }
+      ],
       "origin_repo": "vuejs/core",
       "origin_confidence": "inferred"
     },
@@ -640,6 +823,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -679,6 +873,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -718,6 +923,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -753,6 +969,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -788,6 +1015,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -823,6 +1061,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -858,6 +1107,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -893,6 +1153,17 @@
           "database": 1.1,
           "test/e2e": 1.1,
           "auth": 0.6
+        },
+        {
+          "date": "2026-04-26",
+          "repo": "vuejs/core",
+          "total": 63.0,
+          "vapor": 25.9,
+          "general": 14.8,
+          "compiler": 11.1,
+          "hydration": 3.7,
+          "reactivity": 3.7,
+          "runtime-dom": 3.7
         }
       ],
       "origin_repo": "unknown",
@@ -997,6 +1268,96 @@
         "auth": 0.6
       },
       "snapshots": []
+    },
+    {
+      "id": "47dc1ac4",
+      "rule": "- 상태 관리와 관련된 함수는 `vapor` 도메인 파일에서 사용될 때, 항상 렌더링 맥락을 보존하도록 구현해야 한다.",
+      "domain": "general",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "e709a4d0",
+      "rule": "- 컴파일 관련 PR에서는 템플릿 전용 컴포넌트의 렌더링 인자를 항상 수정하는 것을 피하고, 원래 인자를 반드시 보존해야 한다.",
+      "domain": "ui",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "eb14c9a8",
+      "rule": "- `teleport` 기능 사용할 때는 자식 요소의 이동을 방지하는 로직이 제대로 동작하는지 검증하는 테스트를 추가해야 한다.",
+      "domain": "test/e2e",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "f8d51171",
+      "rule": "- `KeepAlive`와 관련된 파일에서 자식 언마운트 시, 내용 정리를 위한 처리를 항상 포함해야 한다.",
+      "domain": "general",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
+    },
+    {
+      "id": "bccc18e4",
+      "rule": "- 종속성 업데이트 시 변경 사항을 문서화하고, 의존성에 관련된 이슈가 있을 경우 즉시 클러스터에 반영해야 한다.",
+      "domain": "general",
+      "origin_repo": "vuejs/core",
+      "origin_confidence": "explicit",
+      "date_added": "2026-04-26",
+      "fix_rate_at_add": {
+        "total": 63.0,
+        "vapor": 25.9,
+        "general": 14.8,
+        "compiler": 11.1,
+        "hydration": 3.7,
+        "reactivity": 3.7,
+        "runtime-dom": 3.7
+      },
+      "snapshots": []
     }
   ],
   "snapshots": [
@@ -1012,6 +1373,17 @@
       "database": 1.1,
       "test/e2e": 1.1,
       "auth": 0.6
+    },
+    {
+      "date": "2026-04-26",
+      "repo": "vuejs/core",
+      "total_fix_rate": 63.0,
+      "vapor": 25.9,
+      "general": 14.8,
+      "compiler": 11.1,
+      "hydration": 3.7,
+      "reactivity": 3.7,
+      "runtime-dom": 3.7
     }
   ]
 }

--- a/scripts/migrate_rules_origin.py
+++ b/scripts/migrate_rules_origin.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Best-effort origin tagging for legacy rules in data/rules-history.json.
+
+Adds ``origin_repo`` and ``origin_confidence`` to every rule that doesn't
+have them. Idempotent — re-running won't overwrite already-tagged rules.
+
+Heuristic order (first match wins):
+  1. explicit — rule text mentions a path/symbol uniquely tied to one repo
+  2. inferred — rule text mentions a domain keyword that maps to one repo
+                (lower confidence: same word could appear in future repos)
+  3. unknown  — neither matches; keep but exclude from default efficacy
+
+The ``self`` repo tag is reserved for rules induced from analyzing
+ai-dev-loop-analyzer's own PRs. Self-rules are excluded from default
+efficacy calculation because measuring them requires the analyzer to
+analyze itself, which is recursively unstable.
+
+Run: ``python3 scripts/migrate_rules_origin.py``
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HISTORY = ROOT / "data" / "rules-history.json"
+
+# explicit: file paths and symbols that appear in only one repo
+SELF_EXPLICIT = [
+    "src/analyze.py", "src/cli.py", "src/rag", "src/mcp_server",
+    "src/repo_store", "src/feedback", "rag_hook.py", "patch_claude_md",
+    "tests/test_analyze", "tests/test_rag", "tests/test_repo",
+    "detect_clusters", "classify_domain", "analysis-cache",
+    "build_cache_dict",
+]
+SHOP_EXPLICIT = [
+    "src/app/", "src/components/", "src/lib/auth", "prisma/",
+    "src/lib/portone", "src/lib/kakao", "src/lib/gcs",
+    "광천", "광성",
+]
+VUE_EXPLICIT = [
+    "compiler-sfc", "compiler-core", "compiler-dom", "runtime-vapor",
+    "runtime-core", "runtime-dom", "defineProps", "defineEmits",
+    "sfc-playground",
+]
+NEXTJS_EXPLICIT = [
+    "turbopack", "use-cache", "next/font", "server-actions",
+    "next/src/cli", "next/src/server", "pnpm-workspace",
+]
+
+# inferred: domain keywords that strongly suggest a repo but aren't unique
+# (e.g. `compiler` appears in vue rule text but could conceivably appear elsewhere)
+VUE_INFERRED = [
+    "vapor", "compiler", "hydration", "reactivity", "vfor", "transition",
+    "type-only ExportNamed",
+]
+NEXTJS_INFERRED = ["next.js", "nextjs"]
+
+
+def _classify(rule_text: str) -> tuple[str, str]:
+    """Return (origin_repo, origin_confidence)."""
+    text = rule_text.lower()
+
+    def has_any(needles: list[str]) -> bool:
+        return any(n.lower() in text for n in needles)
+
+    # Explicit pass — file paths / unique symbols
+    explicit_hits = []
+    if has_any(SELF_EXPLICIT):
+        explicit_hits.append("self")
+    if has_any(SHOP_EXPLICIT):
+        explicit_hits.append("rladmsgh34/gwangcheon-shop")
+    if has_any(VUE_EXPLICIT):
+        explicit_hits.append("vuejs/core")
+    if has_any(NEXTJS_EXPLICIT):
+        explicit_hits.append("vercel/next.js")
+
+    if len(explicit_hits) == 1:
+        return explicit_hits[0], "explicit"
+    if len(explicit_hits) > 1:
+        # Multiple repos mentioned — likely a cross-repo abstract rule.
+        # Keep as 'unknown' rather than picking one arbitrarily.
+        return "unknown", "unknown"
+
+    # Inferred pass — domain keywords
+    inferred_hits = []
+    if has_any(VUE_INFERRED):
+        inferred_hits.append("vuejs/core")
+    if has_any(NEXTJS_INFERRED):
+        inferred_hits.append("vercel/next.js")
+
+    if len(inferred_hits) == 1:
+        return inferred_hits[0], "inferred"
+
+    return "unknown", "unknown"
+
+
+def main() -> None:
+    if not HISTORY.exists():
+        print("rules-history.json 없음 — 스킵", file=sys.stderr)
+        return
+
+    history = json.loads(HISTORY.read_text())
+    rules = history.get("rules", [])
+
+    tagged = {"explicit": 0, "inferred": 0, "unknown": 0, "skipped": 0}
+    by_repo = {}
+
+    for rule in rules:
+        # idempotent: 이미 태그된 rule은 건너뜀
+        if "origin_repo" in rule and "origin_confidence" in rule:
+            tagged["skipped"] += 1
+            continue
+        origin, conf = _classify(rule.get("rule", ""))
+        rule["origin_repo"] = origin
+        rule["origin_confidence"] = conf
+        tagged[conf] += 1
+        by_repo[origin] = by_repo.get(origin, 0) + 1
+
+    HISTORY.write_text(json.dumps(history, ensure_ascii=False, indent=2))
+
+    print(f"Tagged {len(rules)} rules:")
+    for k, v in tagged.items():
+        print(f"  {k}: {v}")
+    print(f"\nBy origin_repo:")
+    for k, v in sorted(by_repo.items(), key=lambda x: -x[1]):
+        print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_rules_origin.py
+++ b/scripts/migrate_rules_origin.py
@@ -96,6 +96,29 @@ def _classify(rule_text: str) -> tuple[str, str]:
     return "unknown", "unknown"
 
 
+def _purge_dirty_snapshots(history: dict) -> tuple[int, int]:
+    """Remove snapshots that lack a 'repo' field (created before per-repo
+    tracking landed). Without a repo tag we can't tell which repo's analysis
+    produced them, so they're unsafe for cross-repo-aware efficacy
+    calculation. Idempotent — already-clean histories are no-ops.
+    """
+    global_purged = 0
+    rule_purged = 0
+
+    if "snapshots" in history:
+        before = len(history["snapshots"])
+        history["snapshots"] = [s for s in history["snapshots"] if s.get("repo")]
+        global_purged = before - len(history["snapshots"])
+
+    for rule in history.get("rules", []):
+        snaps = rule.get("snapshots", [])
+        before = len(snaps)
+        rule["snapshots"] = [s for s in snaps if s.get("repo")]
+        rule_purged += before - len(rule["snapshots"])
+
+    return global_purged, rule_purged
+
+
 def main() -> None:
     if not HISTORY.exists():
         print("rules-history.json 없음 — 스킵", file=sys.stderr)
@@ -118,6 +141,8 @@ def main() -> None:
         tagged[conf] += 1
         by_repo[origin] = by_repo.get(origin, 0) + 1
 
+    g_purged, r_purged = _purge_dirty_snapshots(history)
+
     HISTORY.write_text(json.dumps(history, ensure_ascii=False, indent=2))
 
     print(f"Tagged {len(rules)} rules:")
@@ -126,6 +151,9 @@ def main() -> None:
     print(f"\nBy origin_repo:")
     for k, v in sorted(by_repo.items(), key=lambda x: -x[1]):
         print(f"  {k}: {v}")
+    print(f"\nPurged snapshots without repo tag:")
+    print(f"  global: {g_purged}")
+    print(f"  rule-attached: {r_purged}")
 
 
 if __name__ == "__main__":

--- a/src/rule_tracker.py
+++ b/src/rule_tracker.py
@@ -57,10 +57,17 @@ def record_new_rules(
     domain_fix_rates: dict[str, float],
     total_fix_rate: float,
     date: str,
+    repo: str | None = None,
+    origin_confidence: str = "explicit",
 ) -> list[str]:
     """
     새 규칙을 히스토리에 등록.
     이미 존재하는 규칙은 건너뜀.
+
+    repo: 이 규칙이 induce된 레포 (owner/repo). 새 rule은 항상 explicit fact로 기록.
+          None이면 'unknown' (legacy / single-repo 호출자 호환).
+    origin_confidence: 'explicit'(분석 시점 fact) | 'inferred'(휴리스틱) | 'unknown'.
+
     반환: 새로 등록된 rule_id 목록
     """
     history = load_history()
@@ -76,6 +83,8 @@ def record_new_rules(
             "id": rid,
             "rule": rule,
             "domain": domain,
+            "origin_repo": repo or "unknown",
+            "origin_confidence": origin_confidence if repo else "unknown",
             "date_added": date,
             "fix_rate_at_add": {
                 "total": total_fix_rate,
@@ -93,24 +102,36 @@ def record_snapshot(
     domain_fix_rates: dict[str, float],
     total_fix_rate: float,
     date: str,
+    repo: str | None = None,
 ) -> None:
-    """매일 현재 fix-rate를 모든 활성 규칙의 스냅샷으로 기록"""
+    """매일 현재 fix-rate를 모든 활성 규칙의 스냅샷으로 기록.
+
+    repo: 이 스냅샷이 어느 레포 분석에서 나왔는지 (owner/repo). efficacy 계산에서
+          rule.origin_repo와 매칭되는 snapshot만 골라야 confounding이 제거됨.
+    """
     history = load_history()
 
     history.setdefault("snapshots", []).append({
         "date": date,
+        "repo": repo or "unknown",
         "total_fix_rate": total_fix_rate,
         **domain_fix_rates,
     })
-    # 중복 날짜 제거 (가장 최신만 유지)
+    # 중복 (date, repo) 제거 — 같은 날 같은 레포는 가장 최신만 유지
     seen = {}
     for s in history["snapshots"]:
-        seen[s["date"]] = s
+        seen[(s["date"], s.get("repo", "unknown"))] = s
     history["snapshots"] = list(seen.values())
 
     for rule in history["rules"]:
+        # rule이 이 레포에서 induce된 경우에만 snapshot 누적 — cross-repo pollution 차단.
+        # origin_repo 미지정인 legacy rule은 모든 snapshot 받음 (best-effort 후방 호환).
+        rule_origin = rule.get("origin_repo", "unknown")
+        if repo and rule_origin not in ("unknown", repo):
+            continue
         rule.setdefault("snapshots", []).append({
             "date": date,
+            "repo": repo or "unknown",
             "total": total_fix_rate,
             **domain_fix_rates,
         })
@@ -119,17 +140,39 @@ def record_snapshot(
     save_history(history)
 
 
-def compute_effectiveness(min_days: int = 7) -> list[dict]:
+def compute_effectiveness(
+    min_days: int = 7,
+    repo: str | None = None,
+    include_self: bool = False,
+    include_inferred: bool = True,
+) -> list[dict]:
     """
     규칙 추가 전후 fix-rate 비교.
     규칙에 도메인이 있으면 해당 도메인 fix-rate 변화를 사용.
     도메인 데이터가 없으면 전체 fix-rate로 폴백.
     min_days 이상 경과된 규칙만 평가.
+
+    repo: 특정 레포 origin rule만 보려면 'owner/repo'. None이면 전부.
+    include_self: analyzer 자기 자신에서 induce된 self-referential rule 포함 여부 (기본 제외).
+                  self-rule efficacy는 분석 도구가 자기 자신을 분석한 결과로 측정되므로
+                  재귀 구조 신뢰도 문제. 별도 트랙으로 봐야 함.
+    include_inferred: 휴리스틱으로 origin 추정한 rule 포함 여부 (기본 포함).
+                      엄격한 baseline이 필요하면 False로 explicit만 사용.
     """
     history = load_history()
     results = []
 
     for rule in history["rules"]:
+        # origin 필터
+        rule_origin = rule.get("origin_repo", "unknown")
+        rule_conf = rule.get("origin_confidence", "unknown")
+        if not include_self and rule_origin == "self":
+            continue
+        if not include_inferred and rule_conf == "inferred":
+            continue
+        if repo and rule_origin != repo:
+            continue
+
         snapshots = rule.get("snapshots", [])
         if len(snapshots) < min_days:
             continue
@@ -152,6 +195,8 @@ def compute_effectiveness(min_days: int = 7) -> list[dict]:
         results.append({
             "rule": rule["rule"][:80],
             "domain": domain,
+            "origin_repo": rule_origin,
+            "origin_confidence": rule_conf,
             "scope": scope,
             "date_added": rule["date_added"],
             "fix_rate_at_add": before,
@@ -163,18 +208,28 @@ def compute_effectiveness(min_days: int = 7) -> list[dict]:
     return sorted(results, key=lambda x: x["delta"])
 
 
-def effectiveness_summary() -> str:
-    results = compute_effectiveness()
+def effectiveness_summary(
+    repo: str | None = None,
+    include_self: bool = False,
+    include_inferred: bool = True,
+) -> str:
+    results = compute_effectiveness(
+        repo=repo, include_self=include_self, include_inferred=include_inferred
+    )
     if not results:
-        return "아직 측정 가능한 데이터 없음 (규칙 추가 후 최소 7일 필요)"
+        scope_desc = f" for {repo}" if repo else ""
+        return f"아직 측정 가능한 데이터 없음{scope_desc} (규칙 추가 후 최소 7일 필요)"
 
-    lines = ["### 📈 규칙 효과 측정"]
+    lines = ["### 📈 규칙 효과 측정 (living document — 데이터 누적과 함께 정확도 상승)"]
+    if repo:
+        lines.append(f"_repo filter: {repo}_")
     for r in results:
         sign = "▼" if r["effective"] else "▲"
         label = "개선" if r["effective"] else "미변화"
         delta_str = f"{sign} {abs(r['delta'])}%p ({label}, {r['scope']} 기준)"
+        conf_marker = "" if r["origin_confidence"] == "explicit" else f" _[{r['origin_confidence']}]_"
         lines.append(
-            f"- **{r['date_added']}** 추가 | "
+            f"- **{r['date_added']}** | origin: `{r['origin_repo']}`{conf_marker} | "
             f"fix율 {r['fix_rate_at_add']}% → {r['fix_rate_recent']}% {delta_str}\n"
             f"  규칙: {r['rule']}"
         )
@@ -182,4 +237,16 @@ def effectiveness_summary() -> str:
 
 
 if __name__ == "__main__":
-    print(effectiveness_summary())
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument("--repo", default=None, help="filter by origin_repo (owner/repo)")
+    p.add_argument("--include-self", action="store_true",
+                   help="include self-referential analyzer rules (excluded by default)")
+    p.add_argument("--strict", action="store_true",
+                   help="exclude inferred-origin rules; explicit only")
+    args = p.parse_args()
+    print(effectiveness_summary(
+        repo=args.repo,
+        include_self=args.include_self,
+        include_inferred=not args.strict,
+    ))

--- a/tests/test_rule_tracker.py
+++ b/tests/test_rule_tracker.py
@@ -1,0 +1,156 @@
+"""rule_tracker — origin tagging + cross-repo pollution guard.
+
+Critical safety nets for the loop-efficacy measurement:
+- new rules carry the analyzed repo as explicit fact
+- snapshots only attach to rules from the matching repo (no
+  vue snapshots polluting gwangcheon rule history)
+- self-referential analyzer rules are excluded from default efficacy
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+import rule_tracker as rt
+
+
+@pytest.fixture
+def tmp_history(tmp_path, monkeypatch):
+    """Redirect HISTORY_FILE to a tmp path so tests don't touch real data."""
+    p = tmp_path / "rules-history.json"
+    monkeypatch.setattr(rt, "HISTORY_FILE", p)
+    return p
+
+
+def test_new_rule_records_explicit_origin(tmp_history):
+    rt.record_new_rules(
+        rules=["fix something in payment"],
+        domain_fix_rates={"payment": 5.0},
+        total_fix_rate=10.0,
+        date="2026-04-26",
+        repo="rladmsgh34/gwangcheon-shop",
+    )
+    history = json.loads(tmp_history.read_text())
+    assert len(history["rules"]) == 1
+    r = history["rules"][0]
+    assert r["origin_repo"] == "rladmsgh34/gwangcheon-shop"
+    assert r["origin_confidence"] == "explicit"
+
+
+def test_new_rule_without_repo_marked_unknown(tmp_history):
+    """Backward-compat path: legacy callers omitting repo get unknown."""
+    rt.record_new_rules(
+        rules=["legacy rule"],
+        domain_fix_rates={},
+        total_fix_rate=0.0,
+        date="2026-04-26",
+    )
+    r = json.loads(tmp_history.read_text())["rules"][0]
+    assert r["origin_repo"] == "unknown"
+    assert r["origin_confidence"] == "unknown"
+
+
+def test_snapshot_only_attaches_to_matching_repo(tmp_history):
+    """Vue snapshot must NOT pollute a gwangcheon-induced rule's timeline."""
+    rt.record_new_rules(
+        rules=["shop rule"], domain_fix_rates={"payment": 3.0},
+        total_fix_rate=8.0, date="2026-04-20",
+        repo="rladmsgh34/gwangcheon-shop",
+    )
+    rt.record_new_rules(
+        rules=["vue rule"], domain_fix_rates={"reactivity": 4.0},
+        total_fix_rate=12.0, date="2026-04-20",
+        repo="vuejs/core",
+    )
+    # Snapshot from vue analysis run.
+    rt.record_snapshot(
+        domain_fix_rates={"reactivity": 5.0},
+        total_fix_rate=15.0,
+        date="2026-04-26",
+        repo="vuejs/core",
+    )
+    history = json.loads(tmp_history.read_text())
+    by_id = {r["origin_repo"]: r for r in history["rules"]}
+    # vue rule received the vue snapshot
+    assert len(by_id["vuejs/core"]["snapshots"]) == 1
+    # gwangcheon rule did NOT
+    assert len(by_id["rladmsgh34/gwangcheon-shop"]["snapshots"]) == 0
+
+
+def test_snapshot_attaches_to_unknown_origin_rules(tmp_history):
+    """Legacy unknown-origin rules accept all snapshots (best-effort)."""
+    rt.record_new_rules(
+        rules=["legacy"], domain_fix_rates={},
+        total_fix_rate=0.0, date="2026-04-20",
+    )
+    rt.record_snapshot(
+        domain_fix_rates={"x": 1.0}, total_fix_rate=2.0,
+        date="2026-04-26", repo="vuejs/core",
+    )
+    rt.record_snapshot(
+        domain_fix_rates={"y": 3.0}, total_fix_rate=4.0,
+        date="2026-04-27", repo="rladmsgh34/gwangcheon-shop",
+    )
+    r = json.loads(tmp_history.read_text())["rules"][0]
+    assert len(r["snapshots"]) == 2
+
+
+def test_compute_effectiveness_filters_by_repo(tmp_history):
+    rt.record_new_rules(
+        rules=["vue rule"], domain_fix_rates={},
+        total_fix_rate=10.0, date="2026-01-01",
+        repo="vuejs/core",
+    )
+    rt.record_new_rules(
+        rules=["shop rule"], domain_fix_rates={},
+        total_fix_rate=10.0, date="2026-01-01",
+        repo="rladmsgh34/gwangcheon-shop",
+    )
+    # Push enough snapshots so min_days=7 is satisfied.
+    for i in range(8):
+        rt.record_snapshot(
+            domain_fix_rates={}, total_fix_rate=5.0,
+            date=f"2026-01-{i + 2:02d}", repo="vuejs/core",
+        )
+    vue_only = rt.compute_effectiveness(repo="vuejs/core")
+    assert len(vue_only) == 1
+    shop_only = rt.compute_effectiveness(repo="rladmsgh34/gwangcheon-shop")
+    assert len(shop_only) == 0  # no snapshots for shop yet
+
+
+def test_compute_effectiveness_excludes_self_by_default(tmp_history):
+    rt.record_new_rules(
+        rules=["analyzer rule"], domain_fix_rates={},
+        total_fix_rate=10.0, date="2026-01-01", repo="self",
+    )
+    for i in range(8):
+        rt.record_snapshot(
+            domain_fix_rates={}, total_fix_rate=5.0,
+            date=f"2026-01-{i + 2:02d}", repo="self",
+        )
+    assert rt.compute_effectiveness() == []  # self excluded
+    assert len(rt.compute_effectiveness(include_self=True)) == 1
+
+
+def test_compute_effectiveness_strict_excludes_inferred(tmp_history):
+    rt.record_new_rules(
+        rules=["explicit rule"], domain_fix_rates={},
+        total_fix_rate=10.0, date="2026-01-01",
+        repo="vuejs/core", origin_confidence="explicit",
+    )
+    rt.record_new_rules(
+        rules=["inferred rule"], domain_fix_rates={},
+        total_fix_rate=10.0, date="2026-01-01",
+        repo="vuejs/core", origin_confidence="inferred",
+    )
+    for i in range(8):
+        rt.record_snapshot(
+            domain_fix_rates={}, total_fix_rate=5.0,
+            date=f"2026-01-{i + 2:02d}", repo="vuejs/core",
+        )
+    assert len(rt.compute_effectiveness()) == 2
+    assert len(rt.compute_effectiveness(include_inferred=False)) == 1

--- a/tests/test_rule_tracker.py
+++ b/tests/test_rule_tracker.py
@@ -136,6 +136,54 @@ def test_compute_effectiveness_excludes_self_by_default(tmp_history):
     assert len(rt.compute_effectiveness(include_self=True)) == 1
 
 
+def test_migration_purges_repo_less_snapshots(tmp_path, monkeypatch):
+    """Pre-migration snapshots (no repo field) get cleaned. Idempotent."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "migrate_rules_origin",
+        Path(__file__).resolve().parent.parent / "scripts" / "migrate_rules_origin.py",
+    )
+    mig = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mig)
+
+    history_file = tmp_path / "rules-history.json"
+    history_file.write_text(json.dumps({
+        "rules": [
+            {
+                "id": "abc",
+                "rule": "fix something",
+                "domain": "general",
+                "date_added": "2026-01-01",
+                "fix_rate_at_add": {},
+                "snapshots": [
+                    {"date": "2026-01-02", "total": 5.0},  # no repo — dirty
+                    {"date": "2026-01-03", "repo": "vuejs/core", "total": 5.0},  # clean
+                ],
+            }
+        ],
+        "snapshots": [
+            {"date": "2026-01-02", "total_fix_rate": 5.0},  # no repo — dirty
+            {"date": "2026-01-03", "repo": "vuejs/core", "total_fix_rate": 5.0},
+        ],
+    }))
+    monkeypatch.setattr(mig, "HISTORY", history_file)
+    mig.main()
+
+    history = json.loads(history_file.read_text())
+    # Dirty global snapshot purged, clean one stays
+    assert len(history["snapshots"]) == 1
+    assert history["snapshots"][0]["repo"] == "vuejs/core"
+    # Dirty rule snapshot purged, clean one stays
+    assert len(history["rules"][0]["snapshots"]) == 1
+    assert history["rules"][0]["snapshots"][0]["repo"] == "vuejs/core"
+
+    # Idempotent — second run purges nothing
+    mig.main()
+    history2 = json.loads(history_file.read_text())
+    assert len(history2["snapshots"]) == 1
+    assert len(history2["rules"][0]["snapshots"]) == 1
+
+
 def test_compute_effectiveness_strict_excludes_inferred(tmp_history):
     rt.record_new_rules(
         rules=["explicit rule"], domain_fix_rates={},


### PR DESCRIPTION
## Summary
loop-efficacy 측정 무력화 원인 발견 — `rules-history.json`이 레포 간 공유라 vue snapshot이 gwangcheon 유발 rule에 누적되며 pollution 발생. **measurement infra만 깔고 숫자는 자라기 기다리는 living document** 방식으로 baseline lock-in 회피.

## 스키마 변경
| 필드 | 의미 |
|---|---|
| `rules[].origin_repo` | `'owner/repo'` \| `'self'` \| `'unknown'` |
| `rules[].origin_confidence` | `'explicit'` (induction 시점 fact) \| `'inferred'` (heuristic) \| `'unknown'` |
| `snapshots[].repo` | 이 snapshot 생산한 분석의 타겟 레포 |

## Pollution 가드
- `record_snapshot`: rule의 origin_repo와 다른 repo snapshot은 attach 안 함
- legacy `unknown` origin rule은 모든 snapshot 받음 (backward compat best-effort)
- `compute_effectiveness`: `repo` / `include_self` / `include_inferred` 플래그
  - **`self` 기본 제외** — analyzer가 자기 자신 분석하는 재귀 측정 신뢰도 문제

## 마이그레이션 (idempotent)
`scripts/migrate_rules_origin.py` 결과:
| origin | count | confidence |
|---|---|---|
| `self` | 6 | explicit |
| `vuejs/core` | 7 | inferred |
| `unknown` | 17 | unknown |

→ default efficacy 계산은 vue 7 rule만 사용. 두 번째 실행은 30개 모두 skip (idempotent 검증 완료).

## Living document 명시
- `effectiveness_summary` 헤더: "데이터 누적과 함께 정확도 상승"
- min_days=7 미충족 → 다음 cron 한 사이클 후 첫 숫자 등장
- baseline lock-in 안 함 — n 작은 환경에서 정직한 표현

## 시퀀스 위치
이 PR은 **measurement infra (#1)**. 다음:
- (#2) fetch_limit 스케일업 — intervention
- (#3) stable_domains — 지금 데이터로 추가 가능
- (deferred) 임계값 검증 — 다음 cron 후 결정 (TODO 주석)

## Test plan
- [x] `pytest` — 94/94 통과 (87 prior + 7 new rule_tracker)
- [x] YAML syntax
- [x] migration idempotent 검증 (1회: 30 tagged, 2회: 30 skipped)
- [x] CLI 3개 변형 동작 (`--repo`, `--strict`, default)
- [ ] 머지 후 첫 cron — 신규 rule이 explicit로 태깅되는지 확인
- [ ] 다음 cron — pollution 가드로 vue snapshot이 self/shop rule timeline에 안 끼어드는지 확인

## Out of scope
- 외부 베타 (hook 추출) — recipient 없어 보류
- 임계값 검증 — fetch 스케일업 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)