### PR TITLE
chore(config): scale vue/nextjs fetch_limit 200 → 800 (intervention)

### DIFF
--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -607,12 +607,6 @@ jobs:
           print(feedback_report(repo=target_repo))
           PYEOF
 
-      - name: rate_limit checkpoint (end)
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          gh api rate_limit --jq ".resources.core | \"[$TARGET_REPO] end: remaining=\\(.remaining) reset=\\(.reset)\""
-
       - name: 히스토리 파일 커밋
         env:
           TARGET_REPO: ${{ env.TARGET_REPO }}
@@ -688,3 +682,13 @@ jobs:
             _fix율: ${{ steps.analyze.outputs.fix_rate }}% | 클러스터: ${{ steps.analyze.outputs.cluster_count }}개_
           labels: "documentation,ai-generated"
           delete-branch: true
+
+      # rate_limit end checkpoint — 매트릭스 iteration 진짜 마지막.
+      # Step 4b (peter-evans/create-pull-request)도 GH_PAT 소비하므로 그 이후로 위치.
+      # `if: always()`로 앞 step 실패 시에도 측정 (intervention 검증 누락 방지).
+      - name: rate_limit checkpoint (end)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh api rate_limit --jq ".resources.core | \"[$TARGET_REPO] end: remaining=\\(.remaining) reset=\\(.reset)\""

--- a/.github/workflows/evolve-rules.yml
+++ b/.github/workflows/evolve-rules.yml
@@ -120,6 +120,15 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           path: target-repo
 
+      # GH_PAT rate-limit 체크포인트 — 매트릭스 iteration 시작.
+      # 끝 직후 동일 호출로 한 번 더 찍어 delta가 그 iteration 실제 소비량.
+      # fetch_limit 스케일업(PR #36) intervention 측정용.
+      - name: rate_limit checkpoint (start)
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh api rate_limit --jq ".resources.core | \"[$TARGET_REPO] start: remaining=\\(.remaining) reset=\\(.reset)\""
+
       # ── Step 1: analyze ─────────────────────────────────────────────────────
       # 프로파일 우선순위:
       #   1. matrix.target.profile (config/repos.json) — 명시적 override
@@ -597,6 +606,12 @@ jobs:
           stats = evaluate(fix_prs, repo=target_repo)
           print(feedback_report(repo=target_repo))
           PYEOF
+
+      - name: rate_limit checkpoint (end)
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh api rate_limit --jq ".resources.core | \"[$TARGET_REPO] end: remaining=\\(.remaining) reset=\\(.reset)\""
 
       - name: 히스토리 파일 커밋
         env:

--- a/config/repos.json
+++ b/config/repos.json
@@ -12,7 +12,7 @@
     "profile": "profiles/examples/vuejs-core.json",
     "schedule": "weekly",
     "post_issues": false,
-    "fetch_limit": 200,
+    "fetch_limit": 800,
     "enabled": true
   },
   {
@@ -20,7 +20,7 @@
     "profile": "profiles/examples/vercel-nextjs.json",
     "schedule": "weekly",
     "post_issues": false,
-    "fetch_limit": 200,
+    "fetch_limit": 800,
     "enabled": true
   }
 ]


### PR DESCRIPTION
## Summary
⚠️ **의도된 intervention** — efficacy 측정에 confound 들어감. routine config tweak 아님.

| 레포 | 기존 | 변경 후 | 정책 |
|---|---|---|---|
| rladmsgh34/gwangcheon-shop | 300 | **300 유지** | daily, fix PR 34개 saturated, 더 키워도 동일 PR 재fetch만 |
| vuejs/core | 200 | **800** | weekly, 200=3주치 → 800=3개월치 cluster window 확대 |
| vercel/next.js | 200 | **800** | 동일 사유 |

## 왜 안전한가
**Incremental fetch (PR #34) 덕분에 fetch_limit는 cost가 아니라 안전 ceiling**. steady-state cron은 cache `generated_at - 14d` 이후만 fetch → 800 ≠ 800 호출 ("최대 800까지, 캐시 비면").

## 운영 영향 추정 (실측 아님)
| 항목 | 현재 | 스케일업 후 | 마진 |
|---|---|---|---|
| API 호출/cron | ~426 | ~882 | GH_PAT 5000/hr → 4118 |
| Workflow 시간 | ~1-2분 | ~6분 | timeout 1hr → 안전 |
| smart-fetch 캡 | 클러스터 PR ~50개 | 동일 (변화 없음) | 무거운 호출 안 늘어남 |

## GH_PAT 공유 점검
- `.github/workflows/` 내 `GH_PAT` 사용 워크플로우: **`evolve-rules.yml` 단독** (다른 워크플로우 컨텐션 없음)
- 외부 레포 공유: `rladmsgh34/gwangcheon-shop`의 `notify-ai-analyzer.yml`이 동일 PAT 사용 — but PR-merge dispatch당 단일 curl 1회라 호출량 무시 수준
- 결론: PAT 컨텐션 위험 없음

## ⚠️ Confound 경고
이 시점 이후 `compute_effectiveness` 결과는 정책 변경의 영향과 분리 불가. baseline 비교 시 PR 머지 SHA 기준으로 before/after 따로 봐야 함. 1주 후 본인이 "fix_rate 갑자기 왜?" 할 때 이 PR 가리키는 git log에서 답.

## Rate-limit 측정 인프라 (보강)
같은 PR에 rate_limit checkpoint 2개 step 추가 — 매트릭스 iteration 진짜 시작/끝 직후 `gh api rate_limit`로 remaining 로깅. delta = 실제 소비량.

**checkpoint 위치 정정**: end checkpoint를 Step 4b (Open target repo PR, peter-evans/create-pull-request via GH_PAT) **이후**로 이동 + `if: always()` 부착. 이전 위치는 gwangcheon Step 4b 호출이 측정에서 누락됐음.

## 롤백 조건
다음 중 하나라도 발생 시 즉시 롤백 (config/repos.json fetch_limit를 200으로 되돌리는 단일 PR):
1. **API 호출 실측이 추정치 1.5배 초과** (~1300 calls/cron 이상 — smart-fetch 가정 깨짐)
2. **Workflow 시간 15분 초과** (timeout 위험권)
3. **GH_PAT remaining이 단일 cron 후 1000 이하로 떨어짐** (다른 워크플로우 동시 실행 시 고갈 위험)
4. **analyze.py OOM 또는 timeout** (smart-fetch 작동 실패)
5. **신규 rule induce가 주당 15건 초과** (rule pollution 가속) — snapshot 누적이 아니라 `record_new_rules`로 새 rule 추가되는 빈도 기준. 정상 범위는 cron당 0~5건이므로 weekly cron 2회 + daily cron 7회 = 최대 9 cron × 5 = 45건이 이론 상한. 실측 normal은 주 5~10건. 15건 초과면 noise 수준.

## Test plan
- [x] `pytest tests/test_repos_config.py` — 8/8 통과 (fetch_limit ≤1500 검증 포함)
- [x] `.github/workflows/` GH_PAT 사용 워크플로우 점검 (evolve-rules.yml 단독)
- [x] rate_limit end checkpoint 위치 — Step 4b 이후로 이동 검증
- [ ] 머지 후 첫 weekly cron — rate_limit checkpoint 로그에서 실제 소비량 확인
- [ ] 동일 cron — workflow 시간 추적, ~6분 대비 5배 이상이면 timeout 위험
- [ ] 머지 후 1주 모니터링 — 위 롤백 조건 5개 중 어느 것도 트리거되지 않는지

## Out of scope
- workflow에 X-RateLimit 자동 알림 (지금은 사후 수동 확인)
- shop fetch_limit 조정 — 별도 결정 사안

🤖 Generated with [Claude Code](https://claude.com/claude-code)