### PR TITLE
feat(web): sync analyzer with profile system + serve tracked repos from cron cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ __pycache__/
 data/repos/**/warning-log.jsonl
 !profiles/**/*.json
 !config/repos.json
+!web/**/*.json
 .DS_Store
 data/chroma/

--- a/web/app/api/analyze/route.ts
+++ b/web/app/api/analyze/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchMergedPRs } from '@/lib/github'
 import { analyze } from '@/lib/analyzer'
+import { getProfileForRepo, isTrackedRepo } from '@/lib/profiles'
+import { loadCachedResult } from '@/lib/cache'
 
 export const maxDuration = 30
 
@@ -12,13 +14,27 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'owner, repo 파라미터 필요' }, { status: 400 })
   }
 
+  const fullRepo = `${owner}/${repo}`
+
   try {
-    const prs = await fetchMergedPRs(owner, repo, 200)
+    // tracked 레포는 commit된 cron 분석 결과 우선 사용 — live fetch보다 빠르고
+    // 분류 정책이 cron과 자동 일치한다.
+    if (await isTrackedRepo(fullRepo)) {
+      const cached = await loadCachedResult(fullRepo)
+      if (cached) {
+        return NextResponse.json(cached, {
+          headers: { 'Cache-Control': 's-maxage=3600, stale-while-revalidate' },
+        })
+      }
+    }
+
+    const profile = await getProfileForRepo(fullRepo)
+    const prs = await fetchMergedPRs(owner, repo, 200, profile)
     if (prs.length === 0) {
       return NextResponse.json({ error: '머지된 PR이 없습니다.' }, { status: 404 })
     }
     const result = analyze(prs)
-    return NextResponse.json(result, {
+    return NextResponse.json({ ...result, source: 'live' }, {
       headers: { 'Cache-Control': 's-maxage=3600, stale-while-revalidate' },
     })
   } catch (e) {

--- a/web/app/api/badge/[owner]/[repo]/route.ts
+++ b/web/app/api/badge/[owner]/[repo]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchMergedPRs } from '@/lib/github'
 import { analyze } from '@/lib/analyzer'
+import { getProfileForRepo, isTrackedRepo } from '@/lib/profiles'
+import { loadCachedResult } from '@/lib/cache'
 
 export const maxDuration = 30
 
@@ -36,10 +38,25 @@ export async function GET(
   { params }: { params: Promise<{ owner: string; repo: string }> }
 ) {
   const { owner, repo } = await params
+  const fullRepo = `${owner}/${repo}`
 
   try {
-    const prs = await fetchMergedPRs(owner, repo, 200)
-    const { summary } = analyze(prs)
+    let summary: { fixRate: number }
+
+    if (await isTrackedRepo(fullRepo)) {
+      const cached = await loadCachedResult(fullRepo)
+      if (cached) {
+        summary = cached.summary
+      } else {
+        const profile = await getProfileForRepo(fullRepo)
+        const prs = await fetchMergedPRs(owner, repo, 200, profile)
+        summary = analyze(prs).summary
+      }
+    } else {
+      const profile = await getProfileForRepo(fullRepo)
+      const prs = await fetchMergedPRs(owner, repo, 200, profile)
+      summary = analyze(prs).summary
+    }
 
     const color =
       summary.fixRate > 20 ? '#e05d44' :

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { fetchMergedPRs, validateRepo } from '../lib/github'
-import { analyze } from '../lib/analyzer'
+import { analyze, type AnalysisResult } from '../lib/analyzer'
+import { getProfileForRepo, isTrackedRepo } from '../lib/profiles'
+import { loadCachedResult } from '../lib/cache'
 import HomeForm from './HomeForm'
 
 const FEATURED_REPOS = [
@@ -21,12 +23,27 @@ interface FeaturedRepoData {
 }
 
 async function fetchFeaturedRepo(owner: string, repo: string): Promise<FeaturedRepoData | null> {
+  const fullRepo = `${owner}/${repo}`
   try {
-    const [repoInfo, prs] = await Promise.all([
-      validateRepo(owner, repo),
-      fetchMergedPRs(owner, repo, 200),
-    ])
-    const result = analyze(prs)
+    const repoInfo = await validateRepo(owner, repo)
+    let result: AnalysisResult
+
+    // tracked 레포는 cache 우선 — featured 그리드 빌드 비용 절감.
+    if (await isTrackedRepo(fullRepo)) {
+      const cached = await loadCachedResult(fullRepo)
+      if (cached) {
+        result = cached
+      } else {
+        const profile = await getProfileForRepo(fullRepo)
+        const prs = await fetchMergedPRs(owner, repo, 200, profile)
+        result = analyze(prs)
+      }
+    } else {
+      const profile = await getProfileForRepo(fullRepo)
+      const prs = await fetchMergedPRs(owner, repo, 200, profile)
+      result = analyze(prs)
+    }
+
     const topDomain = result.domainCounts[0]?.domain ?? null
     return {
       owner,

--- a/web/app/r/[owner]/[repo]/ResultClient.tsx
+++ b/web/app/r/[owner]/[repo]/ResultClient.tsx
@@ -36,9 +36,11 @@ interface Props {
   repo: string
   meta: { stars: number; description: string; language: string }
   benchmark: Benchmark
+  source?: 'cache' | 'live'
+  generatedAt?: string
 }
 
-export default function ResultClient({ result, owner, repo, meta, benchmark }: Props) {
+export default function ResultClient({ result, owner, repo, meta, benchmark, source = 'live', generatedAt }: Props) {
   const [copied, setCopied] = useState(false)
   const [badgeCopied, setBadgeCopied] = useState(false)
   const { summary, clusters, domainCounts, aiVsHuman, trend } = result
@@ -83,6 +85,13 @@ export default function ResultClient({ result, owner, repo, meta, benchmark }: P
               <p className="mt-1 text-sm text-gray-500">{meta.description}</p>
             )}
             <p className="mt-1 text-xs text-gray-600">⭐ {meta.stars.toLocaleString()}</p>
+            {source === 'cache' ? (
+              <p className="mt-1 text-xs text-emerald-500/80">
+                tracked repo · 캐시 결과 ({generatedAt ?? '시점 미상'}) — cron 분석과 일치
+              </p>
+            ) : (
+              <p className="mt-1 text-xs text-gray-600">live fetch — 최신 200개 PR 분석</p>
+            )}
           </div>
           <button
             onClick={copyShare}

--- a/web/app/r/[owner]/[repo]/page.tsx
+++ b/web/app/r/[owner]/[repo]/page.tsx
@@ -1,5 +1,7 @@
 import { fetchMergedPRs, validateRepo, fetchLanguagePatterns } from '@/lib/github'
-import { analyze } from '@/lib/analyzer'
+import { analyze, type AnalysisResult } from '@/lib/analyzer'
+import { getProfileForRepo, isTrackedRepo } from '@/lib/profiles'
+import { loadCachedResult } from '@/lib/cache'
 import ResultClient from './ResultClient'
 
 interface Props {
@@ -13,19 +15,40 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function ResultPage({ params }: Props) {
   const { owner, repo } = await params
+  const fullRepo = `${owner}/${repo}`
 
   try {
-    const [prs, repoMeta, langPatterns] = await Promise.all([
-      fetchMergedPRs(owner, repo, 200),
-      validateRepo(owner, repo),
-      fetchLanguagePatterns(),
-    ])
+    const repoMeta = await validateRepo(owner, repo)
+    const langPatterns = await fetchLanguagePatterns()
 
-    if (prs.length === 0) {
-      return <ErrorPage message="머지된 PR이 없습니다." owner={owner} repo={repo} />
+    let result: AnalysisResult
+    let source: 'cache' | 'live' = 'live'
+    let generatedAt: string | undefined
+
+    // tracked 레포는 commit된 cron 분석 결과 우선. live fetch 비용 절감 + cron과 동일 분류.
+    if (await isTrackedRepo(fullRepo)) {
+      const cached = await loadCachedResult(fullRepo)
+      if (cached) {
+        result = cached
+        source = 'cache'
+        generatedAt = cached.generatedAt
+      } else {
+        const profile = await getProfileForRepo(fullRepo)
+        const prs = await fetchMergedPRs(owner, repo, 200, profile)
+        if (prs.length === 0) {
+          return <ErrorPage message="머지된 PR이 없습니다." owner={owner} repo={repo} />
+        }
+        result = analyze(prs)
+      }
+    } else {
+      const profile = await getProfileForRepo(fullRepo)
+      const prs = await fetchMergedPRs(owner, repo, 200, profile)
+      if (prs.length === 0) {
+        return <ErrorPage message="머지된 PR이 없습니다." owner={owner} repo={repo} />
+      }
+      result = analyze(prs)
     }
 
-    const result = analyze(prs)
     const langStats = langPatterns?.languages[repoMeta.language] ?? null
     const allFixRates = langPatterns?.repo_results
       .filter(r => r.language === repoMeta.language)
@@ -38,6 +61,8 @@ export default async function ResultPage({ params }: Props) {
         repo={repo}
         meta={repoMeta}
         benchmark={{ langStats, allFixRates, language: repoMeta.language }}
+        source={source}
+        generatedAt={generatedAt}
       />
     )
   } catch (e) {

--- a/web/lib/analyzer.ts
+++ b/web/lib/analyzer.ts
@@ -1,4 +1,7 @@
-// PR 히스토리 분석 엔진 — analyze.py의 TypeScript 포트
+// PR 히스토리 분석 엔진 — analyze.py의 TypeScript 포트.
+// 분류 정책은 profile-driven (scope-first → file/title pattern). hardcoded regex 제거.
+
+import type { Profile } from './profiles'
 
 export interface PR {
   number: number
@@ -37,26 +40,23 @@ export interface AnalysisResult {
   trend: TrendPoint[]
 }
 
-const DOMAIN_PATTERNS: [string, RegExp][] = [
-  ['ci/cd',        /deploy|docker|dockerfile|ci\b|workflow|buildx|healthcheck|compose|musl|alpine/i],
-  ['auth',         /auth|login|signup|session|jwt|credential|signin/i],
-  ['payment',      /payment|portone|checkout|order|cart|purchase|결제|주문|장바구니/i],
-  ['database',     /prisma|migration|schema/i],
-  ['security',     /csp|xss|csrf|rate.?limit|sanitize|allowlist/i],
-  ['external-api', /stripe|twilio|sendgrid|s3\b|cloudfront|firebase|slack|webhook|kakao|postcode|우편번호|google.?maps|gcs|sentry|daum|portone|toss|naver|coolsms|gcp\b|aws\b|azure/i],
-  ['test/e2e',     /\.test\.|\.spec\.|e2e|playwright|vitest|coverage/i],
-  ['maintenance',  /refactor|cleanup|rename|deprecat|rewrite|reorganize/i],
-  ['docs',         /readme|changelog|docs?\b|document/i],
-  ['config',       /next\.config|env\.ts|tsconfig|biome|tailwind|npmrc|eslint|prettier|lint\b/i],
-]
+const SCOPE_RE = /^\w+\(([^)]+)\):?/i
 
-export function isFixPR(title: string): boolean {
-  return /^(fix|hotfix|bugfix|revert|regression|bug)\b/i.test(title)
+export function isFixPR(title: string, profile: Profile): boolean {
+  return profile.fixPrRegex.test(title)
 }
 
-export function classifyDomain(title: string, files: string[] = []): string {
+/** scope-first: `fix(scope):` → scope_to_domain → 매칭 없으면 file/title regex. */
+export function classifyDomain(title: string, files: string[], profile: Profile): string {
+  const scopeMatch = title.match(SCOPE_RE)
+  if (scopeMatch) {
+    const scope = scopeMatch[1].toLowerCase()
+    for (const [key, domain] of Object.entries(profile.scopeToDomain)) {
+      if (scope.includes(key)) return domain
+    }
+  }
   const combined = [title, ...files].join(' ')
-  for (const [domain, pattern] of DOMAIN_PATTERNS) {
+  for (const [domain, pattern] of profile.domainPatterns) {
     if (pattern.test(combined)) return domain
   }
   return 'general'
@@ -116,7 +116,8 @@ export function analyze(prs: PR[]): AnalysisResult {
     .map(([domain, fixCount]) => ({ domain, fixCount }))
     .sort((a, b) => b.fixCount - a.fixCount)
 
-  // AI vs human
+  // AI vs human (Co-Authored-By: Claude만 감지) — single-arm 환경에서 노이즈 큼.
+  // 캐시 경로에서는 비어있고 live 경로에서만 채워진다.
   const aiPRs = prs.filter(p => p.isAiGenerated)
   const humanPRs = prs.filter(p => !p.isAiGenerated)
   const aiFixPRs = aiPRs.filter(p => p.isFix)

--- a/web/lib/cache.ts
+++ b/web/lib/cache.ts
@@ -1,16 +1,18 @@
 // Per-repo analysis cache reader — workflow가 data/repos/{owner__repo}/analysis-cache.json에
 // 누적해둔 결과를 web에서 재사용. live fetch보다 빠르고 cron 분석과 일치.
 //
+// Vercel serverless에선 web/ 외부 파일을 읽을 수 없어 GitHub raw URL로 fetch.
+// Next의 1시간 revalidate cache로 cold-start 외엔 무비용.
+//
 // 캐시 스키마는 src/analyze.py의 build_cache_dict() 출력 — web의 AnalysisResult와
 // 일부 필드만 겹침. 변환 시 부재 필드(trend, riskyFiles 전체, full ai/human breakdown)는
 // 빈 값 + source 마커로 표시.
 
-import { promises as fs } from 'fs'
-import path from 'path'
-
 import type { AnalysisResult } from './analyzer'
 
-const MONOREPO_ROOT = path.resolve(process.cwd(), '..')
+const RAW_BASE =
+  'https://raw.githubusercontent.com/rladmsgh34/ai-dev-loop-analyzer/main'
+const REVALIDATE_SECONDS = 3600
 
 interface CachedAnalysis {
   generated_at: string
@@ -37,20 +39,15 @@ function repoSlug(repo: string): string {
 export async function loadCachedResult(
   repo: string
 ): Promise<CachedAnalysisResult | null> {
-  const cachePath = path.join(
-    MONOREPO_ROOT,
-    'data',
-    'repos',
-    repoSlug(repo),
-    'analysis-cache.json'
-  )
-  let raw: string
+  const url = `${RAW_BASE}/data/repos/${repoSlug(repo)}/analysis-cache.json`
+  let cache: CachedAnalysis
   try {
-    raw = await fs.readFile(cachePath, 'utf-8')
+    const res = await fetch(url, { next: { revalidate: REVALIDATE_SECONDS } })
+    if (!res.ok) return null
+    cache = (await res.json()) as CachedAnalysis
   } catch {
     return null
   }
-  const cache: CachedAnalysis = JSON.parse(raw)
 
   return {
     source: 'cache',

--- a/web/lib/cache.ts
+++ b/web/lib/cache.ts
@@ -1,0 +1,93 @@
+// Per-repo analysis cache reader — workflow가 data/repos/{owner__repo}/analysis-cache.json에
+// 누적해둔 결과를 web에서 재사용. live fetch보다 빠르고 cron 분석과 일치.
+//
+// 캐시 스키마는 src/analyze.py의 build_cache_dict() 출력 — web의 AnalysisResult와
+// 일부 필드만 겹침. 변환 시 부재 필드(trend, riskyFiles 전체, full ai/human breakdown)는
+// 빈 값 + source 마커로 표시.
+
+import { promises as fs } from 'fs'
+import path from 'path'
+
+import type { AnalysisResult } from './analyzer'
+
+const MONOREPO_ROOT = path.resolve(process.cwd(), '..')
+
+interface CachedAnalysis {
+  generated_at: string
+  repo: string
+  fix_rate: number
+  summary: { total_prs: number; fix_prs: number; fix_rate: number }
+  risky_files: { file: string; fix_count: number; domain: string }[]
+  domain_counts: { domain: string; fix_count: number }[]
+  ai_weak_domains: { domain: string; count: number }[]
+  clusters: { start: number; end: number; size: number; domain: string }[]
+}
+
+export interface CachedAnalysisResult extends AnalysisResult {
+  source: 'cache'
+  generatedAt: string
+}
+
+/** 'owner/repo' → 'owner__repo' (repo_store.repo_slug() 정책 일치). */
+function repoSlug(repo: string): string {
+  return repo.replace('/', '__')
+}
+
+/** tracked 레포의 캐시를 읽어 web의 AnalysisResult로 변환. 없으면 null. */
+export async function loadCachedResult(
+  repo: string
+): Promise<CachedAnalysisResult | null> {
+  const cachePath = path.join(
+    MONOREPO_ROOT,
+    'data',
+    'repos',
+    repoSlug(repo),
+    'analysis-cache.json'
+  )
+  let raw: string
+  try {
+    raw = await fs.readFile(cachePath, 'utf-8')
+  } catch {
+    return null
+  }
+  const cache: CachedAnalysis = JSON.parse(raw)
+
+  return {
+    source: 'cache',
+    generatedAt: cache.generated_at,
+    summary: {
+      totalPRs: cache.summary.total_prs ?? 0,
+      fixPRs: cache.summary.fix_prs ?? 0,
+      fixRate: cache.summary.fix_rate ?? cache.fix_rate ?? 0,
+    },
+    // cache의 cluster는 PR detail 없음 — start/end/size/domain만.
+    clusters: cache.clusters.map(c => ({
+      prs: [],
+      domain: c.domain,
+      start: c.start,
+      end: c.end,
+    })),
+    riskyFiles: cache.risky_files.map(f => ({
+      file: f.file,
+      fixCount: f.fix_count,
+      domain: f.domain,
+    })),
+    domainCounts: cache.domain_counts.map(d => ({
+      domain: d.domain,
+      fixCount: d.fix_count,
+    })),
+    // cache는 ai_weak_domains만 — full ai/human breakdown 부재.
+    // 표시단에서 source==='cache'면 위젯 비활성/축약 처리 필요.
+    aiVsHuman: {
+      ai: {
+        total: 0,
+        fixCount: 0,
+        fixRate: 0,
+        weakDomains: cache.ai_weak_domains ?? [],
+      },
+      human: { total: 0, fixCount: 0, fixRate: 0 },
+    },
+    // cache에 시계열 trend 부재 — live fetch에서만 채워짐.
+    trend: [],
+  }
+}

--- a/web/lib/github.ts
+++ b/web/lib/github.ts
@@ -1,4 +1,5 @@
 import { classifyDomain, isFixPR, type PR } from './analyzer'
+import type { Profile } from './profiles'
 
 const GH_API = 'https://api.github.com'
 const GH_GRAPHQL = 'https://api.github.com/graphql'
@@ -61,11 +62,16 @@ const MERGED_PRS_QUERY = `
   }
 `
 
-export async function fetchMergedPRs(owner: string, repo: string, limit = 200): Promise<PR[]> {
+export async function fetchMergedPRs(
+  owner: string,
+  repo: string,
+  limit = 200,
+  profile: Profile,
+): Promise<PR[]> {
   const prs: PR[] = []
   let cursor: string | null = null
 
-  const authHeaders = process.env.GITHUB_TOKEN
+  const authHeaders: Record<string, string> = process.env.GITHUB_TOKEN
     ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
     : {}
 
@@ -115,8 +121,8 @@ export async function fetchMergedPRs(owner: string, repo: string, limit = 200): 
         mergedAt: pr.mergedAt,
         additions: pr.additions,
         deletions: pr.deletions,
-        isFix: isFixPR(title),
-        domain: classifyDomain(title),
+        isFix: isFixPR(title, profile),
+        domain: classifyDomain(title, [], profile),
         isAiGenerated,
       })
 

--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -1,0 +1,98 @@
+// Profile loader — Python src/analyze.py와 동일한 분류 정책을 TS로 포팅.
+// scope-first 매칭이 핵심 — 같은 매칭 결과를 보장해야 web과 cron 분석이 어긋나지 않음.
+
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export interface Profile {
+  name: string
+  fixPrRegex: RegExp
+  domainPatterns: [string, RegExp][]
+  scopeToDomain: Record<string, string>
+}
+
+interface RawProfile {
+  name?: string
+  fix_pr_regex?: string
+  domain_patterns?: [string, string][]
+  scope_to_domain?: Record<string, string>
+}
+
+interface RepoConfig {
+  repo: string
+  profile: string | null
+  schedule: 'daily' | 'weekly'
+  post_issues: boolean
+  fetch_limit: number
+  enabled: boolean
+}
+
+// monorepo root — web/은 ai-dev-loop-analyzer/web, profiles/config는 그 위에.
+const MONOREPO_ROOT = path.resolve(process.cwd(), '..')
+const CONFIG_PATH = path.join(MONOREPO_ROOT, 'config', 'repos.json')
+const DEFAULT_PROFILE_PATH = path.join(MONOREPO_ROOT, 'profiles', 'default.json')
+
+let _configCache: RepoConfig[] | null = null
+const _profileCache = new Map<string, Profile>()
+
+async function loadRepoConfig(): Promise<RepoConfig[]> {
+  if (_configCache) return _configCache
+  try {
+    const raw = await fs.readFile(CONFIG_PATH, 'utf-8')
+    _configCache = JSON.parse(raw) as RepoConfig[]
+    return _configCache
+  } catch {
+    _configCache = []
+    return _configCache
+  }
+}
+
+async function loadProfileFromPath(profilePath: string): Promise<Profile | null> {
+  if (_profileCache.has(profilePath)) {
+    return _profileCache.get(profilePath)!
+  }
+  try {
+    const raw = await fs.readFile(profilePath, 'utf-8')
+    const parsed = JSON.parse(raw) as RawProfile
+    const profile: Profile = {
+      name: parsed.name ?? path.basename(profilePath, '.json'),
+      fixPrRegex: parsed.fix_pr_regex
+        ? new RegExp(parsed.fix_pr_regex, 'i')
+        : /^(fix|hotfix|bugfix|patch)\b/i,
+      domainPatterns: (parsed.domain_patterns ?? []).map(
+        ([name, pat]) => [name, new RegExp(pat, 'i')] as [string, RegExp]
+      ),
+      scopeToDomain: parsed.scope_to_domain ?? {},
+    }
+    _profileCache.set(profilePath, profile)
+    return profile
+  } catch {
+    return null
+  }
+}
+
+/** 특정 repo의 프로파일을 결정. config에 등록 안 됐거나 profile=null이면 default. */
+export async function getProfileForRepo(repo: string): Promise<Profile> {
+  const config = await loadRepoConfig()
+  const entry = config.find(c => c.repo === repo)
+  if (entry?.profile) {
+    const fullPath = path.join(MONOREPO_ROOT, entry.profile)
+    const loaded = await loadProfileFromPath(fullPath)
+    if (loaded) return loaded
+  }
+  const fallback = await loadProfileFromPath(DEFAULT_PROFILE_PATH)
+  if (fallback) return fallback
+  // 최후 폴백 — profile 파일 자체가 없으면 빈 프로파일 (모두 general로 떨어짐)
+  return {
+    name: 'empty',
+    fixPrRegex: /^(fix|hotfix|bugfix|patch)\b/i,
+    domainPatterns: [],
+    scopeToDomain: {},
+  }
+}
+
+/** repo가 tracked 목록(config/repos.json)에 있는지. cache lookup의 게이트. */
+export async function isTrackedRepo(repo: string): Promise<boolean> {
+  const config = await loadRepoConfig()
+  return config.some(c => c.repo === repo && c.enabled)
+}

--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -1,8 +1,8 @@
 // Profile loader — Python src/analyze.py와 동일한 분류 정책을 TS로 포팅.
 // scope-first 매칭이 핵심 — 같은 매칭 결과를 보장해야 web과 cron 분석이 어긋나지 않음.
-
-import { promises as fs } from 'fs'
-import path from 'path'
+//
+// Vercel serverless에선 web/ 외부 파일을 읽을 수 없어 fs 대신 GitHub raw로 fetch.
+// Next의 1시간 revalidate cache가 cold-start만 살짝 느리고 그 외엔 무비용.
 
 export interface Profile {
   name: string
@@ -27,48 +27,48 @@ interface RepoConfig {
   enabled: boolean
 }
 
-// monorepo root — web/은 ai-dev-loop-analyzer/web, profiles/config는 그 위에.
-const MONOREPO_ROOT = path.resolve(process.cwd(), '..')
-const CONFIG_PATH = path.join(MONOREPO_ROOT, 'config', 'repos.json')
-const DEFAULT_PROFILE_PATH = path.join(MONOREPO_ROOT, 'profiles', 'default.json')
+const RAW_BASE =
+  'https://raw.githubusercontent.com/rladmsgh34/ai-dev-loop-analyzer/main'
+const REVALIDATE_SECONDS = 3600
 
 let _configCache: RepoConfig[] | null = null
 const _profileCache = new Map<string, Profile>()
 
-async function loadRepoConfig(): Promise<RepoConfig[]> {
-  if (_configCache) return _configCache
+async function fetchJson<T>(url: string): Promise<T | null> {
   try {
-    const raw = await fs.readFile(CONFIG_PATH, 'utf-8')
-    _configCache = JSON.parse(raw) as RepoConfig[]
-    return _configCache
-  } catch {
-    _configCache = []
-    return _configCache
-  }
-}
-
-async function loadProfileFromPath(profilePath: string): Promise<Profile | null> {
-  if (_profileCache.has(profilePath)) {
-    return _profileCache.get(profilePath)!
-  }
-  try {
-    const raw = await fs.readFile(profilePath, 'utf-8')
-    const parsed = JSON.parse(raw) as RawProfile
-    const profile: Profile = {
-      name: parsed.name ?? path.basename(profilePath, '.json'),
-      fixPrRegex: parsed.fix_pr_regex
-        ? new RegExp(parsed.fix_pr_regex, 'i')
-        : /^(fix|hotfix|bugfix|patch)\b/i,
-      domainPatterns: (parsed.domain_patterns ?? []).map(
-        ([name, pat]) => [name, new RegExp(pat, 'i')] as [string, RegExp]
-      ),
-      scopeToDomain: parsed.scope_to_domain ?? {},
-    }
-    _profileCache.set(profilePath, profile)
-    return profile
+    const res = await fetch(url, { next: { revalidate: REVALIDATE_SECONDS } })
+    if (!res.ok) return null
+    return (await res.json()) as T
   } catch {
     return null
   }
+}
+
+async function loadRepoConfig(): Promise<RepoConfig[]> {
+  if (_configCache) return _configCache
+  const data = await fetchJson<RepoConfig[]>(`${RAW_BASE}/config/repos.json`)
+  _configCache = data ?? []
+  return _configCache
+}
+
+async function loadProfileByRelPath(relPath: string): Promise<Profile | null> {
+  if (_profileCache.has(relPath)) {
+    return _profileCache.get(relPath)!
+  }
+  const parsed = await fetchJson<RawProfile>(`${RAW_BASE}/${relPath}`)
+  if (!parsed) return null
+  const profile: Profile = {
+    name: parsed.name ?? relPath,
+    fixPrRegex: parsed.fix_pr_regex
+      ? new RegExp(parsed.fix_pr_regex, 'i')
+      : /^(fix|hotfix|bugfix|patch)\b/i,
+    domainPatterns: (parsed.domain_patterns ?? []).map(
+      ([name, pat]) => [name, new RegExp(pat, 'i')] as [string, RegExp]
+    ),
+    scopeToDomain: parsed.scope_to_domain ?? {},
+  }
+  _profileCache.set(relPath, profile)
+  return profile
 }
 
 /** 특정 repo의 프로파일을 결정. config에 등록 안 됐거나 profile=null이면 default. */
@@ -76,13 +76,12 @@ export async function getProfileForRepo(repo: string): Promise<Profile> {
   const config = await loadRepoConfig()
   const entry = config.find(c => c.repo === repo)
   if (entry?.profile) {
-    const fullPath = path.join(MONOREPO_ROOT, entry.profile)
-    const loaded = await loadProfileFromPath(fullPath)
+    const loaded = await loadProfileByRelPath(entry.profile)
     if (loaded) return loaded
   }
-  const fallback = await loadProfileFromPath(DEFAULT_PROFILE_PATH)
+  const fallback = await loadProfileByRelPath('profiles/default.json')
   if (fallback) return fallback
-  // 최후 폴백 — profile 파일 자체가 없으면 빈 프로파일 (모두 general로 떨어짐)
+  // 최후 폴백 — raw fetch까지 실패하면 빈 프로파일 (모두 general로 떨어짐)
   return {
     name: 'empty',
     fixPrRegex: /^(fix|hotfix|bugfix|patch)\b/i,

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // 부모 디렉토리(gwangcheon-shop)에도 pnpm-lock.yaml이 있어 Turbopack의 workspace 추론이
+  // 잘못 잡힘 → '@/' alias가 엉뚱한 src/lib을 가리키게 됨. web/ 자체를 root로 명시.
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
 };
 
 export default nextConfig;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
사용자 점검: web/은 src/analyze.py와 분류 정책 어긋남 (regex 하드코딩, scope 무시) + tracked 레포도 매번 GitHub fetch (committed cache 무시).

옵션 B (analyzer.ts 동기화 + tracked 레포 cache 사용) 적용. C/D는 별도 PR.

## 변경
| 항목 | 변경 |
|---|---|
| `lib/profiles.ts` (신규) | JSON 프로파일 로딩, `config/repos.json` 기반 repo→profile 매핑, 모듈 캐싱 |
| `lib/cache.ts` (신규) | `data/repos/{slug}/analysis-cache.json` 읽기, Python 스키마 → AnalysisResult 어댑터 |
| `lib/analyzer.ts` | 하드코딩 DOMAIN_PATTERNS 제거, classifyDomain은 Profile 받음, scope-first |
| `lib/github.ts` | fetchMergedPRs가 profile 받아 fetch 시점 분류 |
| 4개 호출처 | api/analyze, api/badge, app/page, r/[owner]/[repo]/page — 모두 cache-first |
| `ResultClient` | source: 'cache' | 'live' caption 추가 |

## 부수 작업 (필요)
| 항목 | 이유 |
|---|---|
| `web/tsconfig.json` (신규) | web에 tsconfig 없었음. Next가 부모 gwangcheon-shop tsconfig를 우연히 사용 중 |
| `web/next.config.ts` turbopack.root 핀 | 부모 pnpm-lock.yaml 때문에 workspace root가 gwangcheon-shop으로 잘못 추론 → @/ alias 깨짐 |
| `.gitignore` `web/**/*.json` allowlist | root `*.json` broad-ignore가 tsconfig 커밋 차단 |

## 캐시 미지원 필드 (의도된 한계)
| 필드 | 캐시 모드 |
|---|---|
| `trend` (월별 시계열) | 빈 배열 (cache 스키마에 부재) |
| `aiVsHuman` 전체 breakdown | 0 (cache는 ai_weak_domains만) |
| `riskyFiles` 상세 diff | 빈 (path + count만) |

ResultClient는 위 필드가 비면 자연 hide → cache 모드 UI는 자동으로 축약 표시.

## Out of scope (별도 PR)
- 옵션 C: 포지셔닝 카피 재정비 + RAG 훅·MCP 도구 설명 페이지
- 옵션 D: aiVsHuman 위젯 deprecate + loop efficacy 위젯 + stable_domains 시각화 (baseline 안정 후)
- File-level PR cache 확장 (riskyFiles 상세 복원 필요 시)

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec next build` success — 10개 라우트 모두 빌드 통과
- [ ] tracked 레포 (vue, next, gwangcheon-shop) /r 페이지 — "tracked repo · 캐시 결과" caption 표시 확인
- [ ] untracked 레포 (예: facebook/react) /r 페이지 — "live fetch" caption + 기존 동작 유지 확인
- [ ] /api/analyze?owner=vuejs&repo=core — cache hit (응답에 source 필드)
- [ ] /api/analyze?owner=facebook&repo=react — live fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)