### PR TITLE
hotfix(web): strip Python (?i) inline flag from profile regexes

### DIFF
--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -51,6 +51,15 @@ async function loadRepoConfig(): Promise<RepoConfig[]> {
   return _configCache
 }
 
+/**
+ * Python regex pattern → JS-compatible.
+ * Python의 `(?i)` 같은 inline flag는 JS RegExp가 못 읽음 — strip하고 'i' arg로 대체.
+ * 다른 Python-only 구문이 추가되면 여기서 함께 처리.
+ */
+function pythonRegexToJs(pattern: string): string {
+  return pattern.replace(/^\(\?[ims]+\)/, '')
+}
+
 async function loadProfileByRelPath(relPath: string): Promise<Profile | null> {
   if (_profileCache.has(relPath)) {
     return _profileCache.get(relPath)!
@@ -60,10 +69,10 @@ async function loadProfileByRelPath(relPath: string): Promise<Profile | null> {
   const profile: Profile = {
     name: parsed.name ?? relPath,
     fixPrRegex: parsed.fix_pr_regex
-      ? new RegExp(parsed.fix_pr_regex, 'i')
+      ? new RegExp(pythonRegexToJs(parsed.fix_pr_regex), 'i')
       : /^(fix|hotfix|bugfix|patch)\b/i,
     domainPatterns: (parsed.domain_patterns ?? []).map(
-      ([name, pat]) => [name, new RegExp(pat, 'i')] as [string, RegExp]
+      ([name, pat]) => [name, new RegExp(pythonRegexToJs(pat), 'i')] as [string, RegExp]
     ),
     scopeToDomain: parsed.scope_to_domain ?? {},
   }


### PR DESCRIPTION
## Summary
실서비스 `/r/<owner>/<repo>` 어떤 untracked 레포에서도 500:
\`\`\`
Invalid regular expression: /(?i)^(...)?(fix|...)\b/i: Invalid group
\`\`\`

원인: Python 프로파일 JSON의 \`fix_pr_regex\`가 \`(?i)\`로 시작 (Python의 inline case-insensitive flag). JS RegExp 생성자는 inline flag 못 읽음.

## Fix
\`pythonRegexToJs(pattern)\` 헬퍼가 leading \`(?i|m|s|ims)\` 블록을 strip. JS는 이미 'i' 플래그 인자로 case-insensitive 처리. fix_pr_regex + domain_patterns 모두 통과시켜 향후 패턴 추가 시 자동 호환.

## Test plan
- [x] \`pnpm exec next build\` clean (10 라우트)
- [x] node REPL regex 동작 검증:
  - \"fix: foo\" → match ✓
  - \"FIX(scope) bar\" → match ✓
  - \"chore: nope\" → no match ✓
- [ ] 머지 + 재배포 후 https://ai-dev-loop-analyzer.rladmsgh34.org/r/shadcn-ui/ui 정상 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)