### PR TITLE
chore: stop analyzing rladmsgh34/gwangcheon-shop

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -1,13 +1,5 @@
 [
   {
-    "repo": "rladmsgh34/gwangcheon-shop",
-    "profile": null,
-    "schedule": "daily",
-    "post_issues": true,
-    "fetch_limit": 300,
-    "enabled": true
-  },
-  {
     "repo": "vuejs/core",
     "profile": "profiles/examples/vuejs-core.json",
     "schedule": "weekly",


### PR DESCRIPTION
## Summary

`config/repos.json`에서 `rladmsgh34/gwangcheon-shop` 엔트리를 제거합니다.

## 배경

- gwangcheon-shop 프로젝트는 2026-04-27자로 본 analyzer 사용을 중단하기로 결정 (`scripts/cross-impact.mjs`로 전환)
- 비활성화 결정 이후에도 daily cron이 계속 실행되어 gwangcheon-shop에 노이즈 이슈 자동 생성:
  - shop#340 (2026-04-28), shop#353 (2026-04-29), shop#355 (2026-04-30)
  - 모두 manual close 완료
- shop 측 트리거 워크플로우(`notify-ai-analyzer.yml`)도 gwangcheon-shop PR #362로 삭제 진행 중

## 변경

- `config/repos.json`에서 gwangcheon-shop 엔트리만 제거
- `vuejs/core`, `vercel/next.js`는 학술 분석용으로 그대로 유지 (`post_issues: false`)

## 영향

- ✅ daily cron이 gwangcheon-shop을 더 이상 분석하지 않음
- ✅ analyzer 자체 기능은 그대로 (vue/next 분석 유지)
- ⚠️ 누적된 `data/repos/rladmsgh34__gwangcheon-shop/*.json` 캐시 파일은 유지 (히스토리 보존, 필요 시 별도 PR로 정리)

## 테스트

- [x] config/repos.json만 변경, 코드 변경 없음
- [x] 머지 후 다음 daily cron(KST 10시)에서 gwangcheon-shop이 매트릭스에서 제외되는지 확인 예정